### PR TITLE
미션 규칙 도메인 기능 추가

### DIFF
--- a/src/main/generated/dailymissionproject/demo/domain/mission/repository/QMission.java
+++ b/src/main/generated/dailymissionproject/demo/domain/mission/repository/QMission.java
@@ -44,6 +44,8 @@ public class QMission extends EntityPathBase<Mission> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> lastModifiedTime = _super.lastModifiedTime;
 
+    public final dailymissionproject.demo.domain.missionRule.repository.QMissionRule missionRule;
+
     public final ListPath<dailymissionproject.demo.domain.participant.repository.Participant, dailymissionproject.demo.domain.participant.repository.QParticipant> participants = this.<dailymissionproject.demo.domain.participant.repository.Participant, dailymissionproject.demo.domain.participant.repository.QParticipant>createList("participants", dailymissionproject.demo.domain.participant.repository.Participant.class, dailymissionproject.demo.domain.participant.repository.QParticipant.class, PathInits.DIRECT2);
 
     public final ListPath<dailymissionproject.demo.domain.post.repository.Post, dailymissionproject.demo.domain.post.repository.QPost> posts = this.<dailymissionproject.demo.domain.post.repository.Post, dailymissionproject.demo.domain.post.repository.QPost>createList("posts", dailymissionproject.demo.domain.post.repository.Post.class, dailymissionproject.demo.domain.post.repository.QPost.class, PathInits.DIRECT2);
@@ -72,6 +74,7 @@ public class QMission extends EntityPathBase<Mission> {
 
     public QMission(Class<? extends Mission> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.missionRule = inits.isInitialized("missionRule") ? new dailymissionproject.demo.domain.missionRule.repository.QMissionRule(forProperty("missionRule"), inits.get("missionRule")) : null;
         this.user = inits.isInitialized("user") ? new dailymissionproject.demo.domain.user.repository.QUser(forProperty("user")) : null;
     }
 

--- a/src/main/generated/dailymissionproject/demo/domain/missionRule/repository/QMissionRule.java
+++ b/src/main/generated/dailymissionproject/demo/domain/missionRule/repository/QMissionRule.java
@@ -1,0 +1,56 @@
+package dailymissionproject.demo.domain.missionRule.repository;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMissionRule is a Querydsl query type for MissionRule
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMissionRule extends EntityPathBase<MissionRule> {
+
+    private static final long serialVersionUID = 1638341521L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMissionRule missionRule = new QMissionRule("missionRule");
+
+    public final BooleanPath deleted = createBoolean("deleted");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final dailymissionproject.demo.domain.mission.repository.QMission mission;
+
+    public final QWeek week;
+
+    public QMissionRule(String variable) {
+        this(MissionRule.class, forVariable(variable), INITS);
+    }
+
+    public QMissionRule(Path<? extends MissionRule> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMissionRule(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMissionRule(PathMetadata metadata, PathInits inits) {
+        this(MissionRule.class, metadata, inits);
+    }
+
+    public QMissionRule(Class<? extends MissionRule> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.mission = inits.isInitialized("mission") ? new dailymissionproject.demo.domain.mission.repository.QMission(forProperty("mission"), inits.get("mission")) : null;
+        this.week = inits.isInitialized("week") ? new QWeek(forProperty("week")) : null;
+    }
+
+}
+

--- a/src/main/generated/dailymissionproject/demo/domain/missionRule/repository/QWeek.java
+++ b/src/main/generated/dailymissionproject/demo/domain/missionRule/repository/QWeek.java
@@ -1,0 +1,49 @@
+package dailymissionproject.demo.domain.missionRule.repository;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QWeek is a Querydsl query type for Week
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QWeek extends BeanPath<Week> {
+
+    private static final long serialVersionUID = 1056190251L;
+
+    public static final QWeek week = new QWeek("week");
+
+    public final BooleanPath fri = createBoolean("fri");
+
+    public final BooleanPath mon = createBoolean("mon");
+
+    public final BooleanPath sat = createBoolean("sat");
+
+    public final BooleanPath sun = createBoolean("sun");
+
+    public final BooleanPath thu = createBoolean("thu");
+
+    public final BooleanPath tue = createBoolean("tue");
+
+    public final BooleanPath wed = createBoolean("wed");
+
+    public QWeek(String variable) {
+        super(Week.class, forVariable(variable));
+    }
+
+    public QWeek(Path<? extends Week> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QWeek(PathMetadata metadata) {
+        super(Week.class, metadata);
+    }
+
+}
+

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -25,7 +25,7 @@ public class MissionController {
     //== 미션 생성==//
     @PostMapping("/create/{userName}")
     public MissionSaveResponseDto save(@PathVariable("userName")String userName
-                                    , @RequestBody MissionSaveRequestDto missionReqDto
+                                    , @RequestPart MissionSaveRequestDto missionReqDto
                                     , @RequestPart MultipartFile file) throws IOException {
         return missionService.save(userName, missionReqDto, file);
     }

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/request/MissionSaveRequestDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/request/MissionSaveRequestDto.java
@@ -1,6 +1,8 @@
 package dailymissionproject.demo.domain.mission.dto.request;
 
 import dailymissionproject.demo.domain.mission.repository.Mission;
+import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
+import dailymissionproject.demo.domain.missionRule.repository.Week;
 import dailymissionproject.demo.domain.user.repository.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +14,7 @@ import java.time.LocalDate;
 @Getter
 public class MissionSaveRequestDto {
 
+    private final Week week;
     private final String title;
     private final String content;
     //private MultipartFile file;
@@ -22,8 +25,9 @@ public class MissionSaveRequestDto {
     private LocalDate endDate;
 
     @Builder
-    private MissionSaveRequestDto(String title, String content
+    private MissionSaveRequestDto(Week week, String title, String content
                                 , LocalDate startDate, LocalDate endDate){
+        this.week = week;
         this.title = title;
         this.content = content;
        // this.file = file;
@@ -32,9 +36,11 @@ public class MissionSaveRequestDto {
     }
 
     public Mission toEntity(User user){
+        MissionRule missionRule = MissionRule.builder().week(week).build();
 
         return Mission.builder()
                 .user(user)
+                .missionRule(missionRule)
                 .title(title)
                 .content(content)
                 .startDate(startDate)

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/Mission.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/Mission.java
@@ -1,6 +1,9 @@
 package dailymissionproject.demo.domain.mission.repository;
 
 import dailymissionproject.demo.common.repository.BaseTimeEntity;
+import dailymissionproject.demo.domain.missionRule.dto.DateDto;
+import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
+import dailymissionproject.demo.domain.missionRule.repository.Week;
 import dailymissionproject.demo.domain.participant.repository.Participant;
 import dailymissionproject.demo.domain.participant.dto.response.ParticipantUserDto;
 import dailymissionproject.demo.domain.post.repository.Post;
@@ -9,6 +12,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -16,12 +20,16 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor
-@Getter
+@Getter @Setter
 public class Mission extends BaseTimeEntity {
 
     @Id @GeneratedValue
     @Column(name = "mission_id")
     private Long id;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_rule_id")
+    private MissionRule missionRule;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -52,9 +60,10 @@ public class Mission extends BaseTimeEntity {
 
     //== 생성 메서드 ==//
     @Builder
-    public Mission(User user, String title, String content, String imageUrl, String credential,
+    public Mission(User user, MissionRule missionRule, String title, String content, String imageUrl, String credential,
                    LocalDate startDate, LocalDate endDate){
         this.user = user;
+        this.missionRule = missionRule;
         this.title = title;
         this.content = content;
         this.credential = credential;
@@ -66,6 +75,48 @@ public class Mission extends BaseTimeEntity {
         this.ended = false;
         this.deleted = false;
     }
+
+    /**
+     * 설명 : 참여 가능한 미션인지 검증
+     *        1. 종료되지 않은 미션
+     *        2. 삭제되지 않은 미션
+     *        3. 시작하지 않은 미션
+     * */
+    public boolean isPossibleToParticipate(LocalDate now){
+
+        // check is ended
+        if(this.ended){
+            return false;
+        }
+
+        // check is deleted
+        if(this.deleted){
+            return false;
+        }
+
+        // check is started
+        if(now.isAfter(this.startDate)){
+            return false;
+        }
+
+        return true;
+    }
+
+    /*
+    * 설명 : 미션 delete 시 자동으로 end
+     */
+    public void delete(){
+
+        this.deleted = true;
+        this.ended = true;
+
+    }
+
+    // 종료
+    public void end(){
+        this.ended = true;
+    }
+
 
     /**
      * 설명 : 미션 참여중인 유저목록 List
@@ -101,7 +152,7 @@ public class Mission extends BaseTimeEntity {
     }
 
     /*
-    *미션 삭제 가능 확인
+    *미션 삭제 가능 검증
      */
     public boolean isDeletable(User user){
 
@@ -128,5 +179,84 @@ public class Mission extends BaseTimeEntity {
             throw new IllegalArgumentException("미션 시작날짜는 미션종료날짜보다 느릴 수 없습니다.");
         }
         return true;
+    }
+
+    public boolean isEndAble(LocalDate now){
+
+        /**
+         * 설명 : 종료날짜가 지난 미션을 종료
+         * */
+        if(now.isAfter(this.endDate)){
+            return true;
+        }
+
+        /**
+         * 설명 : 모두 강퇴시 참여자가 0명인 미션을 종료
+         * */
+        if(getParticipantCountNotBanned()==0){
+            return true;
+        }
+
+        return false;
+    }
+
+    /*
+    * 설명 : week 주의 일주일간 날짜 + 제출의무 요일인지 반환
+    *   ex) 메서드 호출 일자 : 2024-07-02 /
+    *       -> 2024-06-30 ~ 2024-07-06
+    *       -> true/true/true/true/true/false/false
+     */
+
+    public List<DateDto> getWeekDates(LocalDate startDate){
+
+        // result list
+        List<DateDto> weekDates = new ArrayList<>();
+
+        /**
+         * 설명 : 일 ~ 월 요일의 날짜  + 제출 의무 요일인지 검증
+         *       ## 입력값으로 받은 now 는 항상 일요일이다.
+         *  */
+        for(int i=0; i<7; i++){
+            LocalDate date = startDate.plusDays(i);
+            String day = date.getDayOfWeek().toString();
+            boolean mandatory = checkMandatory(day);
+
+            DateDto dateDto = DateDto.builder()
+                    .date(date)
+                    .day(day)
+                    .mandatory(mandatory)
+                    .build();
+
+            weekDates.add(dateDto);
+        }
+
+        return weekDates;
+    }
+
+    /**
+     * 설명 : String 값인 요일(SUM/MON/TUE...)이 input 으로 주어졌을 때
+     *        해당 요일이 제출 의무 요일인지 검증
+     *  */
+    public boolean checkMandatory(String day){
+
+        Week week = this.missionRule.getWeek();
+
+        if(day.equals("SUNDAY")){
+            return week.isSun();
+        }else if(day.equals("MONDAY")){
+            return week.isMon();
+        }else if(day.equals("TUESDAY")){
+            return week.isTue();
+        }else if(day.equals("WEDNESDAY")){
+            return week.isWed();
+        }else if(day.equals("THURSDAY")){
+            return week.isThu();
+        }else if(day.equals("FRIDAY")){
+            return week.isFri();
+        }else if(day.equals("SATURDAY")){
+            return week.isSat();
+        }
+
+        return false;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/missionRule/dto/DateDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/missionRule/dto/DateDto.java
@@ -1,0 +1,20 @@
+package dailymissionproject.demo.domain.missionRule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class DateDto {
+    private LocalDate date;
+    private String day;
+    private boolean mandatory;
+
+    @Builder
+    public DateDto(LocalDate date, String day, boolean mandatory){
+        this.date = date;
+        this.day = day;
+        this.mandatory =  mandatory;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/missionRule/repository/MissionRule.java
+++ b/src/main/java/dailymissionproject/demo/domain/missionRule/repository/MissionRule.java
@@ -1,0 +1,66 @@
+package dailymissionproject.demo.domain.missionRule.repository;
+
+import dailymissionproject.demo.domain.mission.repository.Mission;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MissionRule {
+
+    @Id @GeneratedValue
+    @Column(name = "mission_rule_id")
+    private Long id;
+
+    @Embedded
+    private Week week;
+
+    @Column(name = "DELETED", nullable = false)
+    private boolean deleted;
+
+    @Builder
+    public MissionRule(Week week){
+        if(week==null){
+            throw new IllegalArgumentException("week 값은 필수사항 입니다.");
+        }
+
+        this.week = week;
+        this.deleted = false;
+    }
+
+    @OneToOne(mappedBy = "missionRule")
+    private Mission mission;
+
+    public void update(Week week){
+
+        if(week==null){
+            throw new IllegalArgumentException("week 값은 필수사항 입니다.");
+        }
+
+        this.week = week;
+    }
+
+    public void delete(){
+        this.deleted = true;
+    }
+
+    //제출요일 검증
+    public boolean isValidWeek(){
+
+        // true if all week == false
+        if(!(this.week.isSun()
+                || this.week.isMon()
+                || this.week.isTue()
+                || this.week.isWed()
+                || this.week.isThu()
+                || this.week.isFri()
+                || this.week.isSat())){
+            throw new IllegalArgumentException("최소 하루의 제출요일을 선택해야 합니다.");
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/missionRule/repository/MissionRuleRepository.java
+++ b/src/main/java/dailymissionproject/demo/domain/missionRule/repository/MissionRuleRepository.java
@@ -1,0 +1,8 @@
+package dailymissionproject.demo.domain.missionRule.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MissionRuleRepository extends JpaRepository<MissionRule, Long> {
+}

--- a/src/main/java/dailymissionproject/demo/domain/missionRule/repository/Week.java
+++ b/src/main/java/dailymissionproject/demo/domain/missionRule/repository/Week.java
@@ -1,0 +1,55 @@
+package dailymissionproject.demo.domain.missionRule.repository;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class Week {
+
+    @Column(name = "SUNDAY", nullable = false)
+    private boolean sun;
+
+    @Column(name = "MONDAY", nullable = false)
+    private boolean mon;
+
+    @Column(name = "TUESDAY", nullable = false)
+    private boolean tue;
+
+    @Column(name = "WEDNESDAY", nullable = false)
+    private boolean wed;
+
+    @Column(name = "THURSDAY", nullable = false)
+    private boolean thu;
+
+    @Column(name = "FRIDAY", nullable = false)
+    private boolean fri;
+
+    @Column(name = "SATURDAY", nullable = false)
+    private boolean sat;
+
+    @Builder
+    public Week(boolean sun, boolean mon, boolean tue, boolean wed, boolean thu, boolean fri, boolean sat){
+        this.sun = sun;
+        this.mon = mon;
+        this.tue = tue;
+        this.wed = wed;
+        this.thu = thu;
+        this.fri = fri;
+        this.sat = sat;
+    }
+
+    public void update(boolean sun, boolean mon, boolean tue, boolean wed, boolean thu, boolean fri, boolean sat){
+        this.sun = sun;
+        this.mon = mon;
+        this.tue = tue;
+        this.wed = wed;
+        this.thu = thu;
+        this.fri = fri;
+        this.sat = sat;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #16 

## 📝작업 내용

> 미션 엔티티와 미션 규칙 엔티티 @OneToOne 관계 설정 추가
> 미션 참여, 삭제, 종료 가능한지 검증 메서드 추가
> 미션 규칙 필드 추가 및 인증 글 제출요일 검증 메서드 추가