### PR TITLE
Pr/21/각 도메인컨트롤러 인가 처리 추가

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/controller/ParticipantController.java
@@ -1,9 +1,11 @@
 package dailymissionproject.demo.domain.participant.controller;
 
+import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.participant.dto.request.ParticipantSaveRequestDto;
 import dailymissionproject.demo.domain.participant.service.ParticipantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,9 +16,9 @@ public class ParticipantController {
     private final ParticipantService participantService;
 
     //== 미션 참여==//
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/join/{userName}")
-    public boolean save(@PathVariable("userName")String userName, @RequestBody ParticipantSaveRequestDto requestDto){
-        return participantService.save(userName, requestDto);
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/join")
+    public boolean save(@AuthenticationPrincipal CustomOAuth2User user, @RequestBody ParticipantSaveRequestDto requestDto){
+        return participantService.save(user.getUsername(), requestDto);
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/user/controller/UserController.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/controller/UserController.java
@@ -7,10 +7,15 @@ import dailymissionproject.demo.domain.user.dto.request.UserReqDto;
 import dailymissionproject.demo.domain.user.dto.response.UserResDto;
 import dailymissionproject.demo.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.units.qual.C;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,6 +30,10 @@ public class UserController {
 
     private final UserService userService;
 
+    /*
+    * 2024-07-09
+    * OAuth2를 통한 로그인으로 변경
+     */
 
     /*
     @PostMapping("/join")
@@ -44,10 +53,8 @@ public class UserController {
    */
 
     @GetMapping("/info")
-    public UserResDto getUser(){
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+    @Cacheable(value = "user", key = "#user.username")
+    public UserResDto getUser(@AuthenticationPrincipal CustomOAuth2User user){
         return userService.getUserInfo(user.getUsername());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #21  

## 📝작업 내용

> User, Mission, Participant 도메인 코드 리펙토링 및 Redis 캐시 설정 추가
- @PreAuthorize 어노테이션을 통한 인가 처리
- @Cacheing 어노테이션을 통한 변동 사항이 적은 조회 데이터 캐시에 저장 기능 추가