### PR TITLE
Pr/26/미션도메인 기능추가 리펙토링

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/mission/Service/MissionService.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/Service/MissionService.java
@@ -12,6 +12,8 @@ import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,9 +52,8 @@ public class MissionService {
         User findUser = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
 
-        //참여 코드 6자로 설정
-        String credential = String.valueOf(UUID.randomUUID()).substring(0, 6);
-        log.info("credential is {}", credential);
+        //참여 코드 5글자로 설정
+        String credential = String.valueOf(UUID.randomUUID()).substring(0, 5);
         String imgUrl = imageService.uploadImg(file);
 
         Mission mission = missionReqDto.toEntity(findUser);
@@ -99,16 +100,17 @@ public class MissionService {
 
     //Hot 미션 불러오기 ==//
     @Transactional(readOnly = true)
-    public List<MissionHotListResponseDto> findHotList(){
+    public List<MissionHotListResponseDto> findHotList(Pageable pageable){
 
         List<MissionHotListResponseDto> res = new ArrayList<>();
 
-        List<Mission> hotLists = missionRepository.findAllByParticipantSize();
+        Slice<Mission> hotLists = missionRepository.findAllByParticipantSize(pageable);
         for(Mission mission : hotLists){
             MissionHotListResponseDto hotMission = MissionHotListResponseDto.builder()
                     .title(mission.getTitle())
                     .content(mission.getContent())
-                    .userName(mission.getUser().getName())
+                    .imgUrl(mission.getImageUrl())
+                    .name(mission.getUser().getName())
                     .startDate(mission.getStartDate())
                     .endDate(mission.getEndDate())
                     .build();
@@ -120,16 +122,17 @@ public class MissionService {
 
     //New 미션 불러오기 ==//
     @Transactional(readOnly = true)
-    public List<MissionNewListResponseDto> findNewList(){
+    public List<MissionNewListResponseDto> findNewList(Pageable pageable){
 
         List<MissionNewListResponseDto> res = new ArrayList<>();
 
-        List<Mission> newLists = missionRepository.findAllByCreatedInMonth();
+        Slice<Mission> newLists = missionRepository.findAllByCreatedInMonth(pageable);
         for(Mission mission : newLists){
             MissionNewListResponseDto newMission = MissionNewListResponseDto.builder()
                     .title(mission.getTitle())
                     .content(mission.getContent())
-                    .userName(mission.getUser().getName())
+                    .imgUrl(mission.getImageUrl())
+                    .name(mission.getUser().getName())
                     .startDate(mission.getStartDate())
                     .endDate(mission.getEndDate())
                     .build();
@@ -141,16 +144,17 @@ public class MissionService {
 
     //모든 미션 불러오기 ==//
     @Transactional(readOnly = true)
-    public List<MissionAllListResponseDto> findAllList(){
+    public List<MissionAllListResponseDto> findAllList(Pageable pageable){
 
         List<MissionAllListResponseDto> res = new ArrayList<>();
 
-        List<Mission> allLists = missionRepository.findAllByCreatedDate();
+        Slice<Mission> allLists = missionRepository.findAllByCreatedDate(pageable);
         for(Mission mission : allLists){
             MissionAllListResponseDto allMission = MissionAllListResponseDto.builder()
                     .title(mission.getTitle())
                     .content(mission.getContent())
-                    .userName(mission.getUser().getName())
+                    .imgUrl(mission.getImageUrl())
+                    .name(mission.getUser().getName())
                     .startDate(mission.getStartDate())
                     .endDate(mission.getEndDate())
                     .build();

--- a/src/main/java/dailymissionproject/demo/domain/mission/Service/MissionService.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/Service/MissionService.java
@@ -50,7 +50,9 @@ public class MissionService {
         User findUser = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
 
-        String credential = String.valueOf(UUID.randomUUID());
+        //참여 코드 6자로 설정
+        String credential = String.valueOf(UUID.randomUUID()).substring(0, 6);
+        log.info("credential is {}", credential);
         String imgUrl = imageService.uploadImg(file);
 
         Mission mission = missionReqDto.toEntity(findUser);

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -14,8 +14,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +33,7 @@ public class MissionController {
 
     //== 미션 생성==//
     @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/create")
+    @PostMapping("/save")
     //@Caching(evict = {
     //        @CacheEvict(value = "missionLists", key = "'hot'"),
     //        @CacheEvict(value = "missionLists", key = "'new'"),
@@ -57,7 +55,7 @@ public class MissionController {
 
     //== 미션 상세 조회 ==//
     @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("/getInfo/{id}")
+    @GetMapping("/{id}")
     @Cacheable(value = "mission", key = "'info'")
     @Operation(summary = "미션 상세 정보 확인", description = "각 미션에 대한 상세정보를 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
@@ -75,7 +73,7 @@ public class MissionController {
     * 방장만 삭제 가능
      */
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     @CacheEvict(value = "mission", key = "'info'")
     @Operation(summary = "미션 삭제", description = "사용자가 미션을 삭제하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
@@ -90,7 +88,7 @@ public class MissionController {
 
 
     //==Hot 미션 목록 가져오기==//
-    @GetMapping("/get/hot")
+    @GetMapping("/hot")
     //@Cacheable(value = "missionLists", key = "'hot'")
     @Operation(summary = "인기 미션 확인", description = "인기 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
@@ -105,7 +103,7 @@ public class MissionController {
 
 
     //==New 미션 목록 가져오기==//
-    @GetMapping("/get/new")
+    @GetMapping("/new")
     //@CacheEvict(value = "missionLists", key = "'new'")
     @Operation(summary = "신규 미션 확인", description = "신규 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
@@ -119,7 +117,7 @@ public class MissionController {
     }
 
     //==모든 미션 목록 가져오기==//
-    @GetMapping("/get/all")
+    @GetMapping("/all")
     //@CacheEvict(value = "missionLists", key = "'all'")
     @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -34,12 +34,12 @@ public class MissionController {
     //== 미션 생성==//
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/save")
-    @Caching(evict = {
-            @CacheEvict(value = "missionLists", key = "'hot-' + #pageable.getPageNumber()"),
-            @CacheEvict(value = "missionLists", key = "'new-' + #pageable.getPageNumber()"),
-            @CacheEvict(value = "missionLists", key = "'all-' + #pageable.getPageNumber()"),
-            @CacheEvict(value = "mission", key = "'info'")
-    })
+    //@Caching(evict = {
+    //        @CacheEvict(value = "missionLists", key = "'hot'"),
+    //        @CacheEvict(value = "missionLists", key = "'new'"),
+    //        @CacheEvict(value = "missionLists", key = "'all'"),
+    //        @CacheEvict(value = "mission", key = "'info'")
+    //})
     @Operation(summary = "미션 생성", description = "사용자가 미션을 생성하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -89,7 +89,7 @@ public class MissionController {
 
     //==Hot 미션 목록 가져오기==//
     @GetMapping("/hot")
-    @Cacheable(value = "missionLists", key = "'hot-' + #pageable.getPageNumber()")
+    //@Cacheable(value = "missionLists", key = "'hot'")
     @Operation(summary = "인기 미션 확인", description = "인기 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -98,15 +98,13 @@ public class MissionController {
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
     public List<MissionHotListResponseDto> findHotList(Pageable pageable){
-        int pageNum = pageable.getPageNumber();
-        log.info("pageable page is {}", pageNum);
         return missionService.findHotList(pageable);
     }
 
 
     //==New 미션 목록 가져오기==//
     @GetMapping("/new")
-    @Cacheable(value = "missionLists", key = "'new-' + #pageable.getPageNumber()")
+    //@CacheEvict(value = "missionLists", key = "'new'")
     @Operation(summary = "신규 미션 확인", description = "신규 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -120,7 +118,7 @@ public class MissionController {
 
     //==모든 미션 목록 가져오기==//
     @GetMapping("/all")
-    @Cacheable(value = "missionLists", key = "'all-' + #pageable.getPageNumber()")
+    //@CacheEvict(value = "missionLists", key = "'all'")
     @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -34,12 +34,12 @@ public class MissionController {
     //== 미션 생성==//
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/save")
-    //@Caching(evict = {
-    //        @CacheEvict(value = "missionLists", key = "'hot'"),
-    //        @CacheEvict(value = "missionLists", key = "'new'"),
-    //        @CacheEvict(value = "missionLists", key = "'all'"),
-    //        @CacheEvict(value = "mission", key = "'info'")
-    //})
+    @Caching(evict = {
+            @CacheEvict(value = "missionLists", key = "'hot-' + #pageable.getPageNumber()"),
+            @CacheEvict(value = "missionLists", key = "'new-' + #pageable.getPageNumber()"),
+            @CacheEvict(value = "missionLists", key = "'all-' + #pageable.getPageNumber()"),
+            @CacheEvict(value = "mission", key = "'info'")
+    })
     @Operation(summary = "미션 생성", description = "사용자가 미션을 생성하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -89,7 +89,7 @@ public class MissionController {
 
     //==Hot 미션 목록 가져오기==//
     @GetMapping("/hot")
-    //@Cacheable(value = "missionLists", key = "'hot'")
+    @Cacheable(value = "missionLists", key = "'hot-' + #pageable.getPageNumber()")
     @Operation(summary = "인기 미션 확인", description = "인기 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -98,13 +98,15 @@ public class MissionController {
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
     public List<MissionHotListResponseDto> findHotList(Pageable pageable){
+        int pageNum = pageable.getPageNumber();
+        log.info("pageable page is {}", pageNum);
         return missionService.findHotList(pageable);
     }
 
 
     //==New 미션 목록 가져오기==//
     @GetMapping("/new")
-    //@CacheEvict(value = "missionLists", key = "'new'")
+    @Cacheable(value = "missionLists", key = "'new-' + #pageable.getPageNumber()")
     @Operation(summary = "신규 미션 확인", description = "신규 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -118,7 +120,7 @@ public class MissionController {
 
     //==모든 미션 목록 가져오기==//
     @GetMapping("/all")
-    //@CacheEvict(value = "missionLists", key = "'all'")
+    @Cacheable(value = "missionLists", key = "'all-' + #pageable.getPageNumber()")
     @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -13,6 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,12 +36,12 @@ public class MissionController {
     //== 미션 생성==//
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/create")
-    @Caching(evict = {
-            @CacheEvict(value = "missionLists", key = "'hot'"),
-            @CacheEvict(value = "missionLists", key = "'new'"),
-            @CacheEvict(value = "missionLists", key = "'all'"),
-            @CacheEvict(value = "mission", key = "'info'")
-    })
+    //@Caching(evict = {
+    //        @CacheEvict(value = "missionLists", key = "'hot'"),
+    //        @CacheEvict(value = "missionLists", key = "'new'"),
+    //        @CacheEvict(value = "missionLists", key = "'all'"),
+    //        @CacheEvict(value = "mission", key = "'info'")
+    //})
     @Operation(summary = "미션 생성", description = "사용자가 미션을 생성하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -47,8 +50,8 @@ public class MissionController {
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
     public MissionSaveResponseDto save(@AuthenticationPrincipal CustomOAuth2User user
-            , @RequestPart MissionSaveRequestDto missionReqDto
-            , @RequestPart MultipartFile file) throws IOException {
+                                        , @RequestPart MissionSaveRequestDto missionReqDto
+                                        , @RequestPart MultipartFile file) throws IOException {
         return missionService.save(user.getUsername(), missionReqDto, file);
     }
 
@@ -88,7 +91,7 @@ public class MissionController {
 
     //==Hot 미션 목록 가져오기==//
     @GetMapping("/get/hot")
-    @Cacheable(value = "missionLists", key = "'hot'")
+    //@Cacheable(value = "missionLists", key = "'hot'")
     @Operation(summary = "인기 미션 확인", description = "인기 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -96,14 +99,14 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public List<MissionHotListResponseDto> findHotList(){
-        return missionService.findHotList();
+    public List<MissionHotListResponseDto> findHotList(Pageable pageable){
+        return missionService.findHotList(pageable);
     }
 
 
     //==New 미션 목록 가져오기==//
     @GetMapping("/get/new")
-    @CacheEvict(value = "missionLists", key = "'new'")
+    //@CacheEvict(value = "missionLists", key = "'new'")
     @Operation(summary = "신규 미션 확인", description = "신규 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -111,13 +114,13 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public List<MissionNewListResponseDto> findNewList(){
-        return missionService.findNewList();
+    public List<MissionNewListResponseDto> findNewList(Pageable pageable){
+        return missionService.findNewList(pageable);
     }
 
     //==모든 미션 목록 가져오기==//
     @GetMapping("/get/all")
-    @CacheEvict(value = "missionLists", key = "'all'")
+    //@CacheEvict(value = "missionLists", key = "'all'")
     @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -125,8 +128,8 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public List<MissionAllListResponseDto> findAllList(){
-        return missionService.findAllList();
+    public List<MissionAllListResponseDto> findAllList(Pageable pageable){
+        return missionService.findAllList(pageable);
     }
 
 }

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -34,12 +34,12 @@ public class MissionController {
     //== 미션 생성==//
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/save")
-    //@Caching(evict = {
-    //        @CacheEvict(value = "missionLists", key = "'hot'"),
-    //        @CacheEvict(value = "missionLists", key = "'new'"),
-    //        @CacheEvict(value = "missionLists", key = "'all'"),
-    //        @CacheEvict(value = "mission", key = "'info'")
-    //})
+    @Caching(evict = {
+            @CacheEvict(value = "missionLists", key = "'hot-' + #pageable.getPageNumber()"),
+            @CacheEvict(value = "missionLists", key = "'new-' + #pageable.getPageNumber()"),
+            @CacheEvict(value = "missionLists", key = "'all-' + #pageable.getPageNumber()"),
+            @CacheEvict(value = "mission", key = "'info'")
+    })
     @Operation(summary = "미션 생성", description = "사용자가 미션을 생성하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -89,7 +89,7 @@ public class MissionController {
 
     //==Hot 미션 목록 가져오기==//
     @GetMapping("/hot")
-    //@Cacheable(value = "missionLists", key = "'hot'")
+    @Cacheable(value = "missionLists", key = "'hot-' + #pageable.getPageNumber()")
     @Operation(summary = "인기 미션 확인", description = "인기 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -104,7 +104,7 @@ public class MissionController {
 
     //==New 미션 목록 가져오기==//
     @GetMapping("/new")
-    //@CacheEvict(value = "missionLists", key = "'new'")
+    @Cacheable(value = "missionLists", key = "'new-' + #pageable.getPageNumber()")
     @Operation(summary = "신규 미션 확인", description = "신규 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
@@ -118,7 +118,7 @@ public class MissionController {
 
     //==모든 미션 목록 가져오기==//
     @GetMapping("/all")
-    //@CacheEvict(value = "missionLists", key = "'all'")
+    @Cacheable(value = "missionLists", key = "'all-' + #pageable.getPageNumber()")
     @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
@@ -1,5 +1,9 @@
 package dailymissionproject.demo.domain.mission.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,10 +28,14 @@ public class MissionAllListResponseDto {
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate startDate;
 
     @Schema(description = "미션 종료일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
     @Builder

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
@@ -20,7 +20,7 @@ public class MissionAllListResponseDto {
     @Schema(description = "미션 썸네일")
     private String imgUrl;
     @Schema(description = "미션 방장")
-    private String userName;
+    private String name;
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -31,11 +31,11 @@ public class MissionAllListResponseDto {
     private LocalDate endDate;
 
     @Builder
-    MissionAllListResponseDto(String title, String content, String imgUrl, String userName, LocalDate startDate, LocalDate endDate) {
+    MissionAllListResponseDto(String title, String content, String imgUrl, String name, LocalDate startDate, LocalDate endDate) {
         this.title = title;
         this.content = content;
         this.imgUrl = imgUrl;
-        this.userName = userName;
+        this.name = name;
 
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
@@ -20,7 +20,7 @@ public class MissionHotListResponseDto {
     @Schema(description = "미션 썸네일")
     private String imgUrl;
     @Schema(description = "방장 이름")
-    private String userName;
+    private String name;
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -31,11 +31,11 @@ public class MissionHotListResponseDto {
     private LocalDate endDate;
 
     @Builder
-    MissionHotListResponseDto(String title, String content, String imgUrl, String userName, LocalDate startDate, LocalDate endDate){
+    MissionHotListResponseDto(String title, String content, String imgUrl, String name, LocalDate startDate, LocalDate endDate){
         this.title = title;
         this.content = content;
         this.imgUrl = imgUrl;
-        this.userName = userName;
+        this.name = name;
 
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
@@ -1,5 +1,10 @@
 package dailymissionproject.demo.domain.mission.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,10 +29,14 @@ public class MissionHotListResponseDto {
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate startDate;
 
     @Schema(description = "미션 종료일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
     @Builder

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
@@ -1,5 +1,9 @@
 package dailymissionproject.demo.domain.mission.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,10 +28,14 @@ public class MissionNewListResponseDto {
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate startDate;
 
     @Schema(description = "미션 종료일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
     @Builder

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
@@ -20,7 +20,7 @@ public class MissionNewListResponseDto {
     @Schema(description = "미션 썸네일")
     private String imgUrl;
     @Schema(description = "미션 방장")
-    private String userName;
+    private String name;
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -31,11 +31,11 @@ public class MissionNewListResponseDto {
     private LocalDate endDate;
 
     @Builder
-    MissionNewListResponseDto(String title, String content, String imgUrl, String userName, LocalDate startDate, LocalDate endDate) {
+    MissionNewListResponseDto(String title, String content, String imgUrl, String name, LocalDate startDate, LocalDate endDate) {
         this.title = title;
         this.content = content;
         this.imgUrl = imgUrl;
-        this.userName = userName;
+        this.name = name;
 
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionResponseDto.java
@@ -24,7 +24,7 @@ public class MissionResponseDto {
     @Schema(description = "방장 PK ID")
     private Long userId;
     @Schema(description = "방장 이름")
-    private String userName;
+    private String name;
 
     @Schema(description = "참여자들 목록")
     private List<ParticipantUserDto> participants = new ArrayList<>();
@@ -43,7 +43,7 @@ public class MissionResponseDto {
         this.content = mission.getContent();
         this.imgUrl = mission.getImageUrl();
         this.userId = mission.getUser().getId();
-        this.userName = mission.getUser().getName();
+        this.name = mission.getUser().getName();
         this.participants = mission.getAllParticipantUser();
         this.startDate = mission.getStartDate();
         this.endDate = mission.getEndDate();

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionResponseDto.java
@@ -1,5 +1,9 @@
 package dailymissionproject.demo.domain.mission.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.participant.dto.response.ParticipantUserDto;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,10 +35,14 @@ public class MissionResponseDto {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "미션 시작일자")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate startDate;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "미션 종료일자")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
     @Builder

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
@@ -1,15 +1,27 @@
 package dailymissionproject.demo.domain.mission.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import java.util.List;
 
 public interface MissionRepositoryCustom {
 
+    //== Pagination 적용 ==//
     //Hot 미션 목록
-    List<Mission> findAllByParticipantSize();
+    Slice<Mission> findAllByParticipantSize(Pageable pageable);
 
     //New 미션 목록
-    List<Mission> findAllByCreatedInMonth();
+    Slice<Mission> findAllByCreatedInMonth(Pageable pageable);
 
-    //전체 미션 목록
-    List<Mission> findAllByCreatedDate();
+    //All 미션 목록
+    Slice<Mission> findAllByCreatedDate(Pageable pageable);
+
+
+
+
+    //List<Mission> findAllByParticipantSize();
+    //List<Mission> findAllByCreatedInMonth();
+
+    //List<Mission> findAllByCreatedDate();
 }

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
@@ -2,6 +2,9 @@ package dailymissionproject.demo.domain.mission.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
@@ -11,6 +14,57 @@ import static dailymissionproject.demo.domain.mission.repository.QMission.missio
 public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
+
+    public Slice<Mission> findAllByParticipantSize(Pageable pageable){
+        List<Mission> missionList = queryFactory
+                .select(mission)
+                .from(mission)
+                .where(mission.deleted.isFalse().and(mission.ended.isFalse()))
+                .orderBy(mission.participants.size().desc(), mission.createdTime.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+        boolean hasNext = false;
+        if(missionList.size() > pageable.getPageSize()){
+            missionList.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl<>(missionList, pageable, hasNext);
+    }
+
+    public Slice<Mission> findAllByCreatedInMonth(Pageable pageable){
+        List<Mission> missionList = queryFactory
+                .select(mission)
+                .from(mission)
+                .where(mission.deleted.isFalse().and(mission.ended.isFalse()))
+                .orderBy(mission.createdTime.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+        boolean hasNext = false;
+        if(missionList.size() > pageable.getPageSize()){
+            missionList.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl<>(missionList, pageable, hasNext);
+    }
+
+    public Slice<Mission> findAllByCreatedDate(Pageable pageable){
+        List<Mission> missionList = queryFactory
+                .select(mission)
+                .from(mission)
+                .orderBy(mission.createdTime.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+        boolean hasNext = false;
+        if(missionList.size() > pageable.getPageSize()){
+            missionList.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl<>(missionList, pageable, hasNext);
+    }
+    /*
     @Override
     public List<Mission> findAllByParticipantSize() {
         return queryFactory
@@ -39,4 +93,6 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .orderBy(mission.createdTime.desc())
                 .fetch();
     }
+
+     */
 }

--- a/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
@@ -10,10 +10,8 @@ import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
-
+import java.time.LocalDate;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -60,6 +58,10 @@ public class ParticipantService {
         //참여 코드 검증
         if(!requestDto.getCredential().equals(mission.getCredential())){
             throw new RuntimeException("참여코드를 확인해주세요.");
+        }
+
+        if(!(mission.isPossibleToParticipate(LocalDate.now()))){
+            throw new RuntimeException("해당 미션은 참여가 불가능한 미션입니다.");
         }
 
         Participant participant = requestDto.toEntity(findUser);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #26   

## 📝작업 내용

> 미션 도메인 기능 추가 및 리팩토링 수행
- Slice를 통한 paging 구현 및 redis 연계 로직 수정
- 컨트롤러계층의 엔드포인트 rest api 설계 규칙에 맞게 수정
   ex) HTTP 메서드로만 행동 정의 /api/mission/get/{id} -> GET : /api/mission/{id}로 수정
- 참여코드 5자리로 수정
- DTO 필드명 수정
- 미션 생성 권한 유저로 수정