### PR TITLE
Pr/51/사용자 닉네임필드 추가

### DIFF
--- a/src/main/generated/dailymissionproject/demo/domain/user/repository/QUser.java
+++ b/src/main/generated/dailymissionproject/demo/domain/user/repository/QUser.java
@@ -38,6 +38,8 @@ public class QUser extends EntityPathBase<User> {
 
     public final StringPath name = createString("name");
 
+    public final StringPath nickname = createString("nickname");
+
     public final ListPath<dailymissionproject.demo.domain.participant.repository.Participant, dailymissionproject.demo.domain.participant.repository.QParticipant> participants = this.<dailymissionproject.demo.domain.participant.repository.Participant, dailymissionproject.demo.domain.participant.repository.QParticipant>createList("participants", dailymissionproject.demo.domain.participant.repository.Participant.class, dailymissionproject.demo.domain.participant.repository.QParticipant.class, PathInits.DIRECT2);
 
     public final ListPath<dailymissionproject.demo.domain.post.repository.Post, dailymissionproject.demo.domain.post.repository.QPost> posts = this.<dailymissionproject.demo.domain.post.repository.Post, dailymissionproject.demo.domain.post.repository.QPost>createList("posts", dailymissionproject.demo.domain.post.repository.Post.class, dailymissionproject.demo.domain.post.repository.QPost.class, PathInits.DIRECT2);

--- a/src/main/java/dailymissionproject/demo/common/repository/CurrentUser.java
+++ b/src/main/java/dailymissionproject/demo/common/repository/CurrentUser.java
@@ -1,0 +1,15 @@
+package dailymissionproject.demo.common.repository;
+
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal()
+public @interface CurrentUser {
+}

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/CustomOAuth2User.java
@@ -6,12 +6,56 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor
 public class CustomOAuth2User implements OAuth2User {
 
-    private final UserDto userDto;
+    private UserDto userDto;
+
+    private Long id;
+    private String email;
+    private String username;
+    private String userNickname;
+    private String imageUrl;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public CustomOAuth2User(Long id, String email, String username, String userNickname, String imageUrl, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.username = username;
+        this.userNickname = userNickname;
+        this.imageUrl = imageUrl;
+        this.authorities = authorities;
+    }
+
+    public static CustomOAuth2User create(UserDto user){
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return "ROLE_USER";
+            }
+        });
+
+        return new CustomOAuth2User(
+                user.getId(),
+                user.getEmail(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getImageUrl(),
+                authorities
+        );
+    }
+
+    public static CustomOAuth2User create(UserDto user, Map<String, Object> attributes){
+        CustomOAuth2User customOAuth2User = CustomOAuth2User.create(user);
+        customOAuth2User.setAttributes(attributes);
+
+        return customOAuth2User;
+    }
 
     @Override
     public Map<String, Object> getAttributes() {
@@ -25,22 +69,29 @@ public class CustomOAuth2User implements OAuth2User {
         collection.add(new GrantedAuthority() {
             @Override
             public String getAuthority() {
-                return userDto.getRole().toString();
+                //return userDto.getRole().toString();
+                return "ROLE_USER";
             }
         });
         return collection;
     }
 
+    public Long getId(){ return id; }
+
     @Override
     public String getName() {
-        return userDto.getName();
+        return String.valueOf(id);
     }
 
     public String getUsername(){
-        return userDto.getUsername();
+        return this.username;
     }
 
     public String getNickname(){
-        return userDto.getNickname();
+        return userNickname;
+    }
+
+    public void setAttributes(Map<String, Object> attributes){
+        this.attributes = attributes;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/CustomOAuth2User.java
@@ -39,4 +39,8 @@ public class CustomOAuth2User implements OAuth2User {
     public String getUsername(){
         return userDto.getUsername();
     }
+
+    public String getNickname(){
+        return userDto.getNickname();
+    }
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/CustomOAuth2User.java
@@ -95,7 +95,4 @@ public class CustomOAuth2User implements OAuth2User {
         this.attributes = attributes;
     }
 
-    public String getNickname(){
-        return userDto.getNickname();
-    }
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/GoogleResponse.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/GoogleResponse.java
@@ -33,4 +33,9 @@ public class GoogleResponse implements OAuth2Response {
     public String getProfileImage() {
         return attribute.get("picture").toString();
     }
+
+    @Override
+    public String getNickname() {
+        return attribute.get("given_name").toString();
+    }
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/NaverResponse.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/NaverResponse.java
@@ -35,4 +35,7 @@ public class NaverResponse implements OAuth2Response{
         return attribute.get("profile_image").toString();
     }
 
+    @Override
+    public String getNickname(){ return attribute.get("nickname").toString(); }
+
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/OAuth2Response.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/OAuth2Response.java
@@ -11,4 +11,7 @@ public interface OAuth2Response {
     String getName();
 
     String getProfileImage();
+
+    String getNickname();
+
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/UserDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/UserDto.java
@@ -12,6 +12,7 @@ public class UserDto {
     private String role;
     private String name;
     private String username;
+    private String nickname;
     private String imageUrl;
     private String email;
 
@@ -20,6 +21,7 @@ public class UserDto {
         return User.builder()
                 .name(userDto.getName())
                 .username(userDto.getUsername())
+                .nickname(userDto.getNickname())
                 .imageUrl(userDto.getImageUrl())
                 .email(userDto.getEmail())
                 .role(Role.valueOf(userDto.getRole()))

--- a/src/main/java/dailymissionproject/demo/domain/auth/dto/UserDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/dto/UserDto.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter @Setter
 public class UserDto {
 
+    private Long id;
     private String role;
     private String name;
     private String username;
@@ -26,5 +27,9 @@ public class UserDto {
                 .email(userDto.getEmail())
                 .role(Role.valueOf(userDto.getRole()))
                 .build();
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/auth/jwt/JWTFilter.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/jwt/JWTFilter.java
@@ -17,8 +17,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+
 import java.io.IOException;
-import java.security.SignatureException;
 
 
 @RequiredArgsConstructor
@@ -65,13 +65,16 @@ public class JWTFilter extends OncePerRequestFilter {
 
             String username = jwtUtil.getUsername(token);
             String role = jwtUtil.getRole(token);
+            Long id = Long.parseLong(jwtUtil.getUserId(token));
 
             UserDto userDto = new UserDto();
+            userDto.setId(id);
             userDto.setUsername(username);
             userDto.setRole("ROLE_USER");
 
             //인증 객체 담기
-            CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+            //CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+            CustomOAuth2User customOAuth2User = CustomOAuth2User.create(userDto);
 
             if(!jwtUtil.validToken(token, customOAuth2User)){
                 log.info("token is invalid");

--- a/src/main/java/dailymissionproject/demo/domain/auth/jwt/JWTUtil.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/jwt/JWTUtil.java
@@ -1,7 +1,6 @@
 package dailymissionproject.demo.domain.auth.jwt;
 
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
-import dailymissionproject.demo.domain.user.repository.Role;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,9 +21,10 @@ public class JWTUtil {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String createJwt(String username, String role, Long expireMs){
+    public String createJwt(Long id, String username, String role, Long expireMs){
 
         return Jwts.builder()
+                .claim("id", Long.toString(id))
                 .claim("username", username)
                 .claim("role" , role)
                 .issuedAt(new Date(System.currentTimeMillis()))
@@ -39,6 +39,10 @@ public class JWTUtil {
     }
     public String getUsername(String token){
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getUserId(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", String.class);
     }
 
     public String getRole(String token){

--- a/src/main/java/dailymissionproject/demo/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/oauth2/CustomSuccessHandler.java
@@ -27,6 +27,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         throws IOException, ServletException {
 
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+        Long id = customUserDetails.getId();
         String username = customUserDetails.getUsername();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -35,7 +36,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         //Role role = Role.valueOf(auth.getAuthority());
 
         String role = auth.getAuthority();
-        String token = jwtUtil.createJwt(username, role,3600*60*60L);
+        String token = jwtUtil.createJwt(id, username, role,3600*60*60L);
 
         //response.addCookie(createCookie("Authorization", token));
         createCookie(response, "Authorization", token);

--- a/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
@@ -46,6 +46,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userDto.setUsername(username);
             userDto.setName(oAuth2Response.getName());
             userDto.setEmail(oAuth2Response.getEmail());
+            userDto.setNickname(oAuth2Response.getNickname());
             userDto.setImageUrl(oAuth2Response.getProfileImage());
             userDto.setRole("USER");
 
@@ -59,6 +60,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             user.setEmail(oAuth2Response.getEmail());
             user.setImageUrl(oAuth2Response.getProfileImage());
             user.setName(oAuth2Response.getName());
+            user.setNickname(oAuth2Response.getNickname());
 
             userRepository.save(user);
 
@@ -66,6 +68,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userDto.setUsername(user.getUsername());
             userDto.setName(oAuth2User.getName());
             userDto.setEmail(oAuth2Response.getEmail());
+            userDto.setNickname(oAuth2Response.getNickname());
             userDto.setImageUrl(oAuth2Response.getProfileImage());
             userDto.setRole("ROLE_USER");
 

--- a/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
@@ -53,6 +53,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             User user = userDto.toEntity(userDto);
             userRepository.save(user);
 
+            userDto.setId(user.getId());
             return new CustomOAuth2User(userDto);
 
         } else {
@@ -71,6 +72,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userDto.setNickname(oAuth2Response.getNickname());
             userDto.setImageUrl(oAuth2Response.getProfileImage());
             userDto.setRole("ROLE_USER");
+            userDto.setId(user.getId());
 
             return new CustomOAuth2User(userDto);
         }

--- a/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
@@ -54,7 +54,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userRepository.save(user);
 
             userDto.setId(user.getId());
-            return new CustomOAuth2User(userDto);
+            return CustomOAuth2User.create(userDto);
 
         } else {
             User user = findUser.get();
@@ -74,7 +74,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userDto.setRole("ROLE_USER");
             userDto.setId(user.getId());
 
-            return new CustomOAuth2User(userDto);
+            return CustomOAuth2User.create(userDto, oAuth2User.getAttributes());
         }
 
     }

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -2,6 +2,7 @@ package dailymissionproject.demo.domain.mission.controller;
 
 import dailymissionproject.demo.common.config.response.GlobalResponse;
 import dailymissionproject.demo.common.meta.MetaService;
+import dailymissionproject.demo.common.repository.CurrentUser;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.dto.request.MissionSaveRequestDto;
@@ -12,11 +13,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -45,11 +44,11 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "미션 생성에 실패하였습니다."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> save(@AuthenticationPrincipal CustomOAuth2User user
+    public ResponseEntity<GlobalResponse> save(@CurrentUser CustomOAuth2User user
                                                 , @RequestPart MissionSaveRequestDto missionReqDto
                                                 , @RequestPart MultipartFile file) throws IOException {
 
-        return ResponseEntity.ok(success(missionService.save((user.getUsername()), missionReqDto, file)));
+        return ResponseEntity.ok(success(missionService.save(user, missionReqDto, file)));
     }
 
     //== 미션 상세 조회 ==//
@@ -80,9 +79,9 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "해당 미션이 존재하지 않습니다."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> delete(@PathVariable("id")Long id, @AuthenticationPrincipal CustomOAuth2User user){
+    public ResponseEntity<GlobalResponse> delete(@PathVariable("id")Long id, @CurrentUser CustomOAuth2User user){
 
-        return ResponseEntity.ok(success(missionService.delete(id, user.getUsername())));
+        return ResponseEntity.ok(success(missionService.delete(id, user)));
     }
 
 

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
@@ -25,8 +25,8 @@ public class MissionAllListResponseDto {
     private String content;
     @Schema(description = "미션 썸네일")
     private String imageUrl;
-    @Schema(description = "미션 방장")
-    private String username;
+    @Schema(description = "미션 방장 닉네임")
+    private String nickname;
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -44,12 +44,12 @@ public class MissionAllListResponseDto {
     private boolean ended;
 
     @Builder
-    MissionAllListResponseDto(Long id, String title, String content, String imageUrl, String username, LocalDate startDate, LocalDate endDate, boolean ended) {
+    MissionAllListResponseDto(Long id, String title, String content, String imageUrl, String nickname, LocalDate startDate, LocalDate endDate, boolean ended) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
-        this.username = username;
+        this.nickname = nickname;
 
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionDetailResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionDetailResponseDto.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
 @Schema(description = "미션 상세 정보 응답 DTO")
-public class MissionResponseDto {
+public class MissionDetailResponseDto {
 
     @Schema(description = "미션 제목")
     private final String title;
@@ -28,8 +28,8 @@ public class MissionResponseDto {
     private final String content;
     @Schema(description = "미션 썸네일 이미지")
     private final String imageUrl;
-    @Schema(description = "방장 이름")
-    private final String username;
+    @Schema(description = "방장 닉네임")
+    private final String nickname;
 
     @Schema(description = "참여자들 목록")
     private List<ParticipantUserDto> participantDto = new ArrayList<>();
@@ -52,12 +52,12 @@ public class MissionResponseDto {
     private final MissionRuleResponseDto missionRuleResponseDto;
 
 
-    public static MissionResponseDto of(Mission mission){
-        return new MissionResponseDto(
+    public static MissionDetailResponseDto of(Mission mission){
+        return new MissionDetailResponseDto(
                 mission.getTitle(),
                 mission.getContent(),
                 mission.getImageUrl(),
-                mission.getUser().getUsername(),
+                mission.getUser().getNickname(),
                 mission.getStartDate(),
                 mission.getEndDate(),
                 MissionRuleResponseDto.of(mission.getMissionRule())
@@ -65,13 +65,13 @@ public class MissionResponseDto {
     }
 
     @Builder
-    public MissionResponseDto(String title, String content, String imageUrl,String username, ParticipantUserDto participantUserDto
+    public MissionDetailResponseDto(String title, String content, String imageUrl, String nickname, List<ParticipantUserDto> participantUserDto
             , LocalDate startDate, LocalDate endDate, MissionRuleResponseDto missionRuleResponseDto ) {
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
-        this.username = username;
-        this.participantDto.add(participantUserDto);
+        this.nickname = nickname;
+        this.participantDto = participantUserDto;;
         this.startDate = startDate;
         this.endDate = endDate;
         this.missionRuleResponseDto = missionRuleResponseDto;

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
@@ -25,8 +25,8 @@ public class MissionHotListResponseDto {
     private String content;
     @Schema(description = "미션 썸네일")
     private String imageUrl;
-    @Schema(description = "방장 이름")
-    private String username;
+    @Schema(description = "방장 닉네임")
+    private String nickname;
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -41,12 +41,12 @@ public class MissionHotListResponseDto {
     private LocalDate endDate;
 
     @Builder
-    MissionHotListResponseDto(Long id, String title, String content, String imageUrl, String username, LocalDate startDate, LocalDate endDate){
+    MissionHotListResponseDto(Long id, String title, String content, String imageUrl, String nickname, LocalDate startDate, LocalDate endDate){
         this.id = id;
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
-        this.username = username;
+        this.nickname = nickname;
         this.startDate = startDate;
         this.endDate = endDate;
     }

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
@@ -25,8 +25,8 @@ public class MissionNewListResponseDto {
     private String content;
     @Schema(description = "미션 썸네일")
     private String imageUrl;
-    @Schema(description = "미션 방장")
-    private String username;
+    @Schema(description = "미션 방장 닉네임")
+    private String nickname;
 
     @Schema(description = "미션 시작일자")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -41,12 +41,12 @@ public class MissionNewListResponseDto {
     private LocalDate endDate;
 
     @Builder
-    MissionNewListResponseDto(Long id, String title, String content, String imageUrl, String username, LocalDate startDate, LocalDate endDate) {
+    MissionNewListResponseDto(Long id, String title, String content, String imageUrl, String nickname, LocalDate startDate, LocalDate endDate) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
-        this.username = username;
+        this.nickname = nickname;
 
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                         mission.title,
                         mission.content,
                         mission.imageUrl,
-                        mission.user.username,
+                        mission.user.nickname,
                         mission.startDate,
                         mission.endDate))
                 .from(mission)
@@ -71,7 +71,7 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                         mission.title,
                         mission.content,
                         mission.imageUrl,
-                        mission.user.username,
+                        mission.user.nickname,
                         mission.startDate,
                         mission.endDate))
                 .from(mission)
@@ -95,7 +95,7 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                         mission.title,
                         mission.content,
                         mission.imageUrl,
-                        mission.user.username,
+                        mission.user.nickname,
                         mission.startDate,
                         mission.endDate,
                         mission.ended))

--- a/src/main/java/dailymissionproject/demo/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/controller/ParticipantController.java
@@ -1,6 +1,7 @@
 package dailymissionproject.demo.domain.participant.controller;
 
 import dailymissionproject.demo.common.config.response.GlobalResponse;
+import dailymissionproject.demo.common.repository.CurrentUser;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.participant.dto.request.ParticipantSaveRequestDto;
 import dailymissionproject.demo.domain.participant.service.ParticipantService;
@@ -11,8 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static dailymissionproject.demo.common.config.response.GlobalResponse.success;
 
@@ -34,7 +37,7 @@ public class ParticipantController {
             @ApiResponse(responseCode = "404", description = "미션 참여에 실패하였습니다."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> save(@AuthenticationPrincipal CustomOAuth2User user, @RequestBody ParticipantSaveRequestDto requestDto){
-        return ResponseEntity.ok(success(participantService.save(user.getUsername(), requestDto)));
+    public ResponseEntity<GlobalResponse> save(@CurrentUser CustomOAuth2User user, @RequestBody ParticipantSaveRequestDto requestDto){
+        return ResponseEntity.ok(success(participantService.save(user, requestDto)));
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
@@ -1,5 +1,6 @@
 package dailymissionproject.demo.domain.participant.service;
 
+import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.mission.repository.MissionRepository;
@@ -40,15 +41,16 @@ public class ParticipantService {
     @Caching(evict = {
             @CacheEvict(value = "mission", allEntries = true)
     })
-    public boolean save(String username, ParticipantSaveRequestDto requestDto){
+    public boolean save(CustomOAuth2User user, ParticipantSaveRequestDto requestDto){
 
         Mission findMission = missionRepository.findById(requestDto.getMissionId()).orElseThrow(() -> new MissionException(MISSION_NOT_FOUND));
 
-        User findUser = userRepository.findByUsername(username)
+        User findUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         //해당 사용자가 해당 미션에 참여한 이력이 있는지 검증
         Optional<Participant> optional = participantRepository.findByMissionAndUser(findMission, findUser);
+
         if(optional.isPresent()){
             if(optional.get().isBanned()){
                 throw new ParticipantException(BAN_HISTORY_EXISTS);

--- a/src/main/java/dailymissionproject/demo/domain/post/controller/PostController.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package dailymissionproject.demo.domain.post.controller;
 
 import dailymissionproject.demo.common.config.response.GlobalResponse;
 import dailymissionproject.demo.common.meta.MetaService;
+import dailymissionproject.demo.common.repository.CurrentUser;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
@@ -16,11 +17,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
-import java.util.List;
 
 import static dailymissionproject.demo.common.config.response.GlobalResponse.success;
 @RestController
@@ -42,11 +42,11 @@ public class PostController {
             @ApiResponse(responseCode = "404", description = "포스트 생성에 실패하였습니다."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> save(@AuthenticationPrincipal CustomOAuth2User user
+    public ResponseEntity<GlobalResponse> save(@CurrentUser CustomOAuth2User user
                     , @RequestPart PostSaveRequestDto postSaveReqDto
                     , @RequestPart MultipartFile file)throws IOException {
 
-        return ResponseEntity.ok(success(postService.save(user.getUsername(), postSaveReqDto, file)));
+        return ResponseEntity.ok(success(postService.save(user, postSaveReqDto, file)));
     }
 
     //== 인증 글 상세 조회==//
@@ -73,8 +73,8 @@ public class PostController {
             @ApiResponse(responseCode = "404", description = "포스트 조회에 실패하였습니다."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> findByUser(@AuthenticationPrincipal CustomOAuth2User user, Pageable pageable){
-        PageResponseDto response = postService.findAllByUser(user.getUsername(), pageable);
+    public ResponseEntity<GlobalResponse> findByUser(@CurrentUser CustomOAuth2User user, Pageable pageable){
+        PageResponseDto response = postService.findAllByUser(user, pageable);
 
         return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
     }

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/PostHistoryDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/PostHistoryDto.java
@@ -16,16 +16,16 @@ import java.util.List;
 public class PostHistoryDto {
 
     private Long userId;
-    private String username;
+    private String nickname;
     private String imageUrl;
     private Boolean banned;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private List<LocalDate> date = new ArrayList<>();
 
     @Builder
-    public PostHistoryDto(Long userId, String username, String imageUrl, Boolean banned){
+    public PostHistoryDto(Long userId, String nickname, String imageUrl, Boolean banned){
         this.userId = userId;
-        this.username = username;
+        this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.banned = banned;
     }

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/PostSubmitDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/PostSubmitDto.java
@@ -13,15 +13,15 @@ import java.time.LocalDateTime;
 public class PostSubmitDto {
 
     private Long userId;
-    private String username;
+    private String nickname;
     private String imageUrl;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
     @Builder
-    public PostSubmitDto(LocalDateTime dateTime, Long userId, String username, String imageUrl){
+    public PostSubmitDto(LocalDateTime dateTime, Long userId, String nickname, String imageUrl){
         this.userId = userId;
-        this.username = username;
+        this.nickname = nickname;
         this.imageUrl = imageUrl;
 
         LocalDateTime check = LocalDateTime.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth(), 3, 0,0);

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostResponseDto.java
@@ -27,8 +27,8 @@ public class PostResponseDto {
     @Schema(description = "포스트 미션 제목")
     private String missionTitle;
 
-    @Schema(description = "포스트 작성자 이름")
-    private String username;
+    @Schema(description = "포스트 작성자 닉네임")
+    private String nickname;
 
     @Schema(description = "포스트 작성자 이미지")
     private String userImageUrl;
@@ -55,7 +55,7 @@ public class PostResponseDto {
         this.id = post.getId();
         this.missionId = post.getMission().getId();
         this.missionTitle = post.getMission().getTitle();
-        this.username = post.getUser().getUsername();
+        this.nickname = post.getUser().getNickname();
         this.userImageUrl = post.getUser().getImageUrl();
         this.title = post.getTitle();
         this.content = post.getContent();
@@ -65,12 +65,12 @@ public class PostResponseDto {
     }
 
     @Builder
-    public PostResponseDto(Long id, Long missionId, String missionTitle, String username, String userImageUrl, String title
+    public PostResponseDto(Long id, Long missionId, String missionTitle, String nickname, String userImageUrl, String title
                         ,String content, String imageUrl, LocalDateTime createdDate, LocalDateTime modifiedDate){
         this.id = id;
         this.missionId = missionId;
         this.missionTitle = missionTitle;
-        this.username = username;
+        this.nickname = nickname;
         this.userImageUrl = userImageUrl;
         this.title = title;
         this.content = content;

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
@@ -43,7 +43,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                         post.id,
                         post.mission.id,
                         post.mission.title,
-                        post.mission.user.username,
+                        post.mission.user.nickname,
                         post.user.imageUrl,
                         post.title,
                         post.content,
@@ -87,7 +87,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                         post.id,
                         post.mission.id,
                         post.mission.title,
-                        post.mission.user.username,
+                        post.mission.user.nickname,
                         post.user.imageUrl,
                         post.title,
                         post.content,
@@ -135,7 +135,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .select(Projections.constructor(PostSubmitDto.class,
                         post.createdDate.as("date"),
                         post.user.id.as("userId"),
-                        post.user.username.as("username"),
+                        post.user.nickname.as("nickname"),
                         post.user.imageUrl.as("imageUrl")
                         ))
                 .from(post)

--- a/src/main/java/dailymissionproject/demo/domain/post/service/PostService.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package dailymissionproject.demo.domain.post.service;
 
 
+import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.image.ImageService;
 import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
@@ -55,12 +56,12 @@ public class PostService {
             @CacheEvict(value = "postLists", allEntries = true),
             @CacheEvict(value = "posts", allEntries = true)
     })
-    public Long save(String username, PostSaveRequestDto requestDto, MultipartFile file) throws IOException {
+    public Long save(CustomOAuth2User user, PostSaveRequestDto requestDto, MultipartFile file) throws IOException {
 
         Mission mission = missionRepository.findByIdAndDeletedIsFalse(requestDto.getMissionId())
                 .orElseThrow(() -> new MissionException(MISSION_NOT_FOUND));
 
-        User findUser = userRepository.findByUsername(username)
+        User findUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         //미션 참여자인지 검증
@@ -87,10 +88,10 @@ public class PostService {
 
     //== 사용자가 작성한 전체 포스트 조회==//
     @Transactional(readOnly = true)
-    @Cacheable(value = "postLists", key = "'user-' + #username")
-    public PageResponseDto findAllByUser(String username, Pageable pageable){
+    @Cacheable(value = "postLists", key = "'user-' + #user.getId()")
+    public PageResponseDto findAllByUser(CustomOAuth2User user, Pageable pageable){
 
-        User findUser = userRepository.findByUsername(username)
+        User findUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         Slice<PostResponseDto> userPostLists = postRepository.findAllByUser(pageable, findUser);

--- a/src/main/java/dailymissionproject/demo/domain/user/controller/UserController.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package dailymissionproject.demo.domain.user.controller;
 
 import dailymissionproject.demo.common.config.response.GlobalResponse;
+import dailymissionproject.demo.common.repository.CurrentUser;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,9 +51,9 @@ public class UserController {
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
 
-    public ResponseEntity<GlobalResponse> getUser(@AuthenticationPrincipal CustomOAuth2User user){
+    public ResponseEntity<GlobalResponse> getUser(@CurrentUser CustomOAuth2User user){
 
-        return ResponseEntity.ok(success(userService.detail(user.getUsername())));
+        return ResponseEntity.ok(success(userService.detail(user)));
     }
 
     @PutMapping("/profile")

--- a/src/main/java/dailymissionproject/demo/domain/user/dto/response/UserDetailResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/dto/response/UserDetailResponseDto.java
@@ -6,20 +6,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
 @Schema(description = "유저 정보 응답 DTO")
-public class UserResDto {
+public class UserDetailResponseDto {
 
     @Schema(description = "유저 닉네임")
-    private  String name;
+    private final String userNickname;
     @Schema(description = "유저 이메일")
-    private  String email;
+    private final String email;
     @Schema(description = "유저 이미지 썸네일")
-    private  String imageUrl;
+    private final String imageUrl;
 
     @Builder
-    UserResDto(String name, String email, String imageUrl){
-        this.name = name;
+    public UserDetailResponseDto(String userNickname, String email, String imageUrl) {
+        this.userNickname = userNickname;
         this.email = email;
         this.imageUrl = imageUrl;
     }

--- a/src/main/java/dailymissionproject/demo/domain/user/dto/response/UserDetailResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/dto/response/UserDetailResponseDto.java
@@ -11,15 +11,15 @@ import lombok.NoArgsConstructor;
 public class UserDetailResponseDto {
 
     @Schema(description = "유저 닉네임")
-    private final String userNickname;
+    private final String nickname;
     @Schema(description = "유저 이메일")
     private final String email;
     @Schema(description = "유저 이미지 썸네일")
     private final String imageUrl;
 
     @Builder
-    public UserDetailResponseDto(String userNickname, String email, String imageUrl) {
-        this.userNickname = userNickname;
+    public UserDetailResponseDto(String nickname, String email, String imageUrl) {
+        this.nickname = nickname;
         this.email = email;
         this.imageUrl = imageUrl;
     }

--- a/src/main/java/dailymissionproject/demo/domain/user/repository/User.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/repository/User.java
@@ -33,6 +33,7 @@ public class User extends BaseTimeEntity {
 
     private String name;
     private String email;
+    private String nickname;
 
     @Column(name = "username")
     private String username;
@@ -46,18 +47,20 @@ public class User extends BaseTimeEntity {
 
 
     @Builder
-    public User(String name, String email, String username, String imageUrl, Role role){
+    public User(String name, String email, String username, String nickname, String imageUrl, Role role){
         this.name = name;
         this.email = email;
         this.username = username;
+        this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.role = role;
     }
 
     @Builder
-    public User(String name, String username, String email, String imageUrl){
+    public User(String name, String username, String nickname, String email, String imageUrl){
         this.name = name;
         this.username = username;
+        this.nickname = nickname;
         this.email = email;
         this.imageUrl = imageUrl;
     }
@@ -77,5 +80,9 @@ public class User extends BaseTimeEntity {
 
     public void setEmail(String email){
         this.email = email;
+    }
+
+    public void setNickname(String nickname){
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/user/service/UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/service/UserService.java
@@ -1,8 +1,9 @@
 package dailymissionproject.demo.domain.user.service;
 
 import dailymissionproject.demo.common.util.S3Util;
+import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.image.ImageService;
-import dailymissionproject.demo.domain.user.dto.response.UserResDto;
+import dailymissionproject.demo.domain.user.dto.response.UserDetailResponseDto;
 import dailymissionproject.demo.domain.user.exception.UserException;
 import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
@@ -26,22 +27,20 @@ public class UserService {
 
     /**
      * 유저 정보 확인
-     * @param username
+     * @param user
      * @return userResDto
      */
     @Transactional(readOnly = true)
-    public UserResDto detail(String username){
+    public UserDetailResponseDto detail(CustomOAuth2User user) {
 
-        User findUser = userRepository.findByUsername(username)
+        User findUser = userRepository.findByUsername(user.getUsername())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-        UserResDto res = UserResDto.builder()
-                .name(username)
+        return UserDetailResponseDto.builder()
+                .userNickname(findUser.getNickname())
                 .email(findUser.getEmail())
                 .imageUrl(findUser.getImageUrl())
                 .build();
-
-        return res;
     }
 
     /**

--- a/src/main/java/dailymissionproject/demo/domain/user/service/UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/service/UserService.java
@@ -33,11 +33,12 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserDetailResponseDto detail(CustomOAuth2User user) {
 
-        User findUser = userRepository.findByUsername(user.getUsername())
+        log.info("user.id = {}", user.getId());
+        User findUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         return UserDetailResponseDto.builder()
-                .userNickname(findUser.getNickname())
+                .nickname(findUser.getNickname())
                 .email(findUser.getEmail())
                 .imageUrl(findUser.getImageUrl())
                 .build();

--- a/src/test/java/dailymissionproject/demo/domain/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/dailymissionproject/demo/domain/WithMockCustomUserSecurityContextFactory.java
@@ -18,10 +18,11 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
         UserDto dto = new UserDto();
+        dto.setId(1L);
         dto.setUsername(annotation.username());
         dto.setRole(annotation.role());
 
-        CustomOAuth2User customOAuth2User = new CustomOAuth2User(dto);
+        CustomOAuth2User customOAuth2User = CustomOAuth2User.create(dto);
 
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());

--- a/src/test/java/dailymissionproject/demo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/user/controller/UserControllerTest.java
@@ -63,6 +63,6 @@ public class UserControllerTest {
 
         resultActions.andExpect(jsonPath("$.success").value("true"));
         resultActions.andExpect(jsonPath("$.code").value("200"));
-        resultActions.andExpect(jsonPath("$.data.userNickname").value("윤성철"));
+        resultActions.andExpect(jsonPath("$.data.nickname").value("윤성철"));
     }
 }

--- a/src/test/java/dailymissionproject/demo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/user/controller/UserControllerTest.java
@@ -3,7 +3,7 @@ package dailymissionproject.demo.domain.user.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.user.WithMockCustomUser;
-import dailymissionproject.demo.domain.user.dto.response.UserResDto;
+import dailymissionproject.demo.domain.user.dto.response.UserDetailResponseDto;
 import dailymissionproject.demo.domain.user.fixture.UserObjectFixture;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
 import dailymissionproject.demo.domain.user.service.UserService;
@@ -45,7 +45,7 @@ public class UserControllerTest {
     @MockBean
     private UserRepository userRepository;
 
-    private final UserResDto response = UserObjectFixture.getUserResponse();
+    private final UserDetailResponseDto response = UserObjectFixture.getUserResponse();
 
 
     @Test
@@ -63,6 +63,6 @@ public class UserControllerTest {
 
         resultActions.andExpect(jsonPath("$.success").value("true"));
         resultActions.andExpect(jsonPath("$.code").value("200"));
-        resultActions.andExpect(jsonPath("$.data.name").value("윤성철"));
+        resultActions.andExpect(jsonPath("$.data.userNickname").value("윤성철"));
     }
 }

--- a/src/test/java/dailymissionproject/demo/domain/user/fixture/UserObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/user/fixture/UserObjectFixture.java
@@ -1,12 +1,12 @@
 package dailymissionproject.demo.domain.user.fixture;
 
-import dailymissionproject.demo.domain.user.dto.response.UserResDto;
+import dailymissionproject.demo.domain.user.dto.response.UserDetailResponseDto;
 
 public class UserObjectFixture {
 
-    public static UserResDto getUserResponse(){
-        return UserResDto.builder()
-                .name("윤성철")
+    public static UserDetailResponseDto getUserResponse(){
+        return UserDetailResponseDto.builder()
+                .userNickname("윤성철")
                 .email("proattacker641@gmail.com")
                 .imageUrl("https://aws-s3.jpg")
                 .build();

--- a/src/test/java/dailymissionproject/demo/domain/user/fixture/UserObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/user/fixture/UserObjectFixture.java
@@ -6,7 +6,7 @@ public class UserObjectFixture {
 
     public static UserDetailResponseDto getUserResponse(){
         return UserDetailResponseDto.builder()
-                .userNickname("윤성철")
+                .nickname("윤성철")
                 .email("proattacker641@gmail.com")
                 .imageUrl("https://aws-s3.jpg")
                 .build();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #50  

## 📝작업 내용

> 미션리스트, 포스트에서 노출되는 유저 정보 수정
- 기존의 유저 고유 이름 disabled 처리
- OAuth2 인증으로부터 닉네임 필드를 받아 User 엔티티에 닉네임 필드 추가 및 DTO 필드 추가 및 수정