### PR TITLE
Pr/61/닉네임 이슈

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/auth/service/CustomOAuth2UserService.java
@@ -40,13 +40,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
         Optional<User> findUser = userRepository.findByUsername(username);
+        Optional<User> findNickname = userRepository.findByNickname(oAuth2Response.getNickname());
         if(!findUser.isPresent()){
 
             UserDto userDto = new UserDto();
             userDto.setUsername(username);
             userDto.setName(oAuth2Response.getName());
             userDto.setEmail(oAuth2Response.getEmail());
-            userDto.setNickname(oAuth2Response.getNickname());
+            if(findNickname.isPresent()){
+                userDto.setNickname(username);
+            } else {
+                userDto.setNickname(oAuth2Response.getNickname());
+            }
             userDto.setImageUrl(oAuth2Response.getProfileImage());
             userDto.setRole("USER");
 

--- a/src/main/java/dailymissionproject/demo/domain/user/exception/UserExceptionCode.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/exception/UserExceptionCode.java
@@ -7,8 +7,8 @@ public enum UserExceptionCode implements ExceptionCode {
 
     SUCCESS(HttpStatus.OK, "OK"),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자가 존재하지 않습니다.");
-
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자가 존재하지 않습니다."),
+    NICKNAME_ALREADY_EXITS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/dailymissionproject/demo/domain/user/repository/UserRepository.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/repository/UserRepository.java
@@ -11,6 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(Long id);
 
+    Optional<User> findByNickname(String nickname);
 
     Optional<User> findByUsername(String username);
 

--- a/src/main/java/dailymissionproject/demo/domain/user/service/UserService.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/service/UserService.java
@@ -15,7 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Optional;
 
+import static dailymissionproject.demo.domain.user.exception.UserExceptionCode.NICKNAME_ALREADY_EXITS;
 import static dailymissionproject.demo.domain.user.exception.UserExceptionCode.USER_NOT_FOUND;
 
 @Service
@@ -56,6 +58,10 @@ public class UserService {
     public UserUpdateResponseDto updateProfile(CustomOAuth2User user, UserUpdateRequestDto request, MultipartFile file) throws IOException {
 
         User findUser = userRepository.findById(user.getId()).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+        Optional<User> hasNicknameUser = userRepository.findByNickname(request.getNickname());
+        // 변경하려는 닉네임이 사용중이면, 에러를 반환한다.
+        if(hasNicknameUser.isPresent()) throw new UserException(NICKNAME_ALREADY_EXITS);
 
         //수정할 프로필 이미지 존재 유무 검증
         if(file != null){

--- a/src/test/java/dailymissionproject/demo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/user/service/UserServiceTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import static dailymissionproject.demo.domain.user.exception.UserExceptionCode.NICKNAME_ALREADY_EXITS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -106,6 +107,23 @@ class UserServiceTest {
 
             //then
             verify(imageService, times(1)).uploadUserS3(any(), any());
+        }
+
+        @Test
+        @DisplayName("유저 정보를 수정할 수 없다.")
+        void update_user_detail_fail_when_nickname_is_using() throws IOException {
+            final String fileName = "userModifyImage";
+            final String contentType = "image/jpeg";
+
+            MockMultipartFile file = new MockMultipartFile("file", fileName, contentType, "test data".getBytes());
+
+            when(userRepository.findById(anyLong())).thenThrow(new UserException(NICKNAME_ALREADY_EXITS));
+
+            UserException userException = assertThrows(UserException.class,
+                    () -> userService.updateProfile(user, updateRequest, file));
+
+            //then
+            assertEquals(NICKNAME_ALREADY_EXITS, userException.getExceptionCode());
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #63    

## 📝작업 내용

> 닉네임 중복 불가
- OAuth 회원 가입 시, 인증 정보에 닉네임이 없는 경우, 고유 ID를 부여하고 저장한다.
- 유저 정보 수정 시, 닉네임 중복 검증 로직 추가
- 닉네임 중복 관련 Exception 추가
-  관련 단위테스트 작성