### PR TITLE
Pr/68/테스트컨테이너 환경을 구성한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,11 @@ dependencies {
 	testImplementation 'org.mockito:mockito-core:4.8.0'
 	testImplementation 'org.mockito:mockito-inline:2.13.0'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api'
-	testImplementation("com.h2database:h2:2.1.214")
+	//testImplementation("com.h2database:h2:2.1.214")
+	testImplementation "org.testcontainers:junit-jupiter:1.19.7"
+	testImplementation "org.testcontainers:mariadb:1.19.7"
+	testImplementation 'org.testcontainers:testcontainers:1.19.7'
+	testImplementation 'org.testcontainers:jdbc:1.19.7'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/test/java/dailymissionproject/demo/global/config/IntegrationTestSupport.java
+++ b/src/test/java/dailymissionproject/demo/global/config/IntegrationTestSupport.java
@@ -1,0 +1,17 @@
+package dailymissionproject.demo.global.config;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class IntegrationTestSupport {
+    @Container
+    MariaDBContainer MARIADB_CONTAINER = new MariaDBContainer("mariadb:10.11");
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #68      

## 📝작업 내용

> test container 설정
- test container 관련 junit, jdbc, mariadb 의존성 추가
- jdbc 관련 properties 파일 수정
- testcontainer Support config 파일 추가