### PR TITLE
Pr/73/미션리스트 객체 수정

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -176,8 +176,8 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> findAllList(Pageable pageable){
-        PageResponseDto response = missionService.findAllList(pageable);
+    public ResponseEntity<GlobalResponse> findAllList(Pageable pageable, @CurrentUser CustomOAuth2User user){
+        PageResponseDto response = missionService.findAllList(pageable, user);
 
         return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
     }

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -134,9 +134,9 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> findHotList(Pageable pageable){
+    public ResponseEntity<GlobalResponse> findHotList(Pageable pageable, @CurrentUser CustomOAuth2User user){
 
-        PageResponseDto response = missionService.findHotList(pageable);
+        PageResponseDto response = missionService.findHotList(pageable, user);
 
         return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
 
@@ -156,9 +156,9 @@ public class MissionController {
             @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> findNewList(Pageable pageable){
+    public ResponseEntity<GlobalResponse> findNewList(Pageable pageable, @CurrentUser CustomOAuth2User user){
 
-        PageResponseDto response = missionService.findNewList(pageable);
+        PageResponseDto response = missionService.findNewList(pageable, user);
 
         return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
     }

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionAllListResponseDto.java
@@ -40,19 +40,23 @@ public class MissionAllListResponseDto {
     @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
+    @Schema(description = "미션 참여중 여부")
+    private boolean participating;
+
     @Schema(description = "미션 종료 여부")
     private boolean ended;
 
     @Builder
-    MissionAllListResponseDto(Long id, String title, String content, String imageUrl, String nickname, LocalDate startDate, LocalDate endDate, boolean ended) {
+    MissionAllListResponseDto(Long id, String title, String content, String imageUrl, String nickname
+            , LocalDate startDate, LocalDate endDate, boolean participating, boolean ended) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
         this.nickname = nickname;
-
         this.startDate = startDate;
         this.endDate = endDate;
+        this.participating = participating;
         this.ended = ended;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionHotListResponseDto.java
@@ -40,6 +40,9 @@ public class MissionHotListResponseDto {
     @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
+    @Schema(description = "미션 참여중 여부")
+    private boolean participating;
+
     @Builder
     MissionHotListResponseDto(Long id, String title, String content, String imageUrl, String nickname, LocalDate startDate, LocalDate endDate){
         this.id = id;

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionNewListResponseDto.java
@@ -40,6 +40,9 @@ public class MissionNewListResponseDto {
     @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate;
 
+    @Schema(description = "미션 참여중 여부")
+    private boolean participating;
+
     @Builder
     MissionNewListResponseDto(Long id, String title, String content, String imageUrl, String nickname, LocalDate startDate, LocalDate endDate) {
         this.id = id;

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
@@ -18,7 +18,7 @@ public interface MissionRepositoryCustom {
     Slice<MissionNewListResponseDto> findAllByCreatedInMonth(Pageable pageable);
 
     //All 미션 목록
-    Slice<MissionAllListResponseDto> findAllByCreatedDate(Pageable pageable);
+    Slice<MissionAllListResponseDto> findAllByCreatedDate(Pageable pageable, Long userId);
     List<Mission> findAllByCreatedDate();
     /*
         @Override

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
@@ -12,10 +12,10 @@ public interface MissionRepositoryCustom {
 
     //== Pagination 적용 ==//
     //Hot 미션 목록
-    Slice<MissionHotListResponseDto> findAllByParticipantSize(Pageable pageable);
+    Slice<MissionHotListResponseDto> findAllByParticipantSize(Pageable pageable, Long userId);
 
     //New 미션 목록
-    Slice<MissionNewListResponseDto> findAllByCreatedInMonth(Pageable pageable);
+    Slice<MissionNewListResponseDto> findAllByCreatedInMonth(Pageable pageable, Long userId);
 
     //All 미션 목록
     Slice<MissionAllListResponseDto> findAllByCreatedDate(Pageable pageable, Long userId);

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
@@ -19,29 +19,20 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
 
-    /*
-    public Slice<Mission> findAllByParticipantSize(Pageable pageable){
-        List<Mission> missionList = queryFactory
-                .select(mission)
-                .from(mission)
-                .where(mission.deleted.isFalse().and(mission.ended.isFalse()))
-                .orderBy(mission.participants.size().desc(), mission.createdTime.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-        boolean hasNext = false;
-        if(missionList.size() > pageable.getPageSize()){
-            missionList.remove(pageable.getPageSize());
-            hasNext = true;
-        }
+    /**
+     * 인기 미션리스트를 반환한다.
+     * @param pageable
+     * @return
+     */
+    public Slice<MissionHotListResponseDto> findAllByParticipantSize(Pageable pageable){
+        List<MissionHotListResponseDto> missionList = fetchByParticipantSize(pageable);
+        boolean hasNext = hasNextPage(missionList, pageable);
+
         return new SliceImpl<>(missionList, pageable, hasNext);
     }
 
-     */
-
-    public Slice<MissionHotListResponseDto> findAllByParticipantSize(Pageable pageable){
-
-        List<MissionHotListResponseDto> missionList = queryFactory
+    private List<MissionHotListResponseDto> fetchByParticipantSize(Pageable pageable){
+        return queryFactory
                 .select(Projections.fields(MissionHotListResponseDto.class,
                         mission.id,
                         mission.title,
@@ -56,16 +47,22 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
-        boolean hasNext = false;
-        if(missionList.size() > pageable.getPageSize()){
-            missionList.remove(pageable.getPageSize());
-            hasNext = true;
-        }
+    }
+
+    /**
+     * 신규 미션리스트를 반환한다.
+     * @param pageable
+     * @return
+     */
+    public Slice<MissionNewListResponseDto> findAllByCreatedInMonth(Pageable pageable){
+        List<MissionNewListResponseDto> missionList = fetchMissionByCreatedInMonth(pageable);
+        boolean hasNext = hasNextPage(missionList, pageable);
+
         return new SliceImpl<>(missionList, pageable, hasNext);
     }
 
-    public Slice<MissionNewListResponseDto> findAllByCreatedInMonth(Pageable pageable){
-        List<MissionNewListResponseDto> missionList = queryFactory
+    private List<MissionNewListResponseDto> fetchMissionByCreatedInMonth(Pageable pageable){
+       return queryFactory
                 .select(Projections.fields(MissionNewListResponseDto.class,
                         mission.id,
                         mission.title,
@@ -80,16 +77,22 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
-        boolean hasNext = false;
-        if(missionList.size() > pageable.getPageSize()){
-            missionList.remove(pageable.getPageSize());
-            hasNext = true;
-        }
+    }
+
+    /**
+     * 전체 미션리스트를 반환한다.
+     * @param pageable
+     * @return
+     */
+    public Slice<MissionAllListResponseDto> findAllByCreatedDate(Pageable pageable){
+        List<MissionAllListResponseDto> missionList = fetchMissionByCreatedDate(pageable);
+        boolean hasNext = hasNextPage(missionList, pageable);
+
         return new SliceImpl<>(missionList, pageable, hasNext);
     }
 
-    public Slice<MissionAllListResponseDto> findAllByCreatedDate(Pageable pageable){
-        List<MissionAllListResponseDto> missionList = queryFactory
+    private List<MissionAllListResponseDto> fetchMissionByCreatedDate(Pageable pageable){
+       return queryFactory
                 .select(Projections.fields(MissionAllListResponseDto.class,
                         mission.id,
                         mission.title,
@@ -104,34 +107,22 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
-        boolean hasNext = false;
-        if(missionList.size() > pageable.getPageSize()){
-            missionList.remove(pageable.getPageSize());
-            hasNext = true;
-        }
-        return new SliceImpl<>(missionList, pageable, hasNext);
-    }
-    /*
-    @Override
-    public List<Mission> findAllByParticipantSize() {
-        return queryFactory
-                .select(mission)
-                .from(mission)
-                .where(mission.deleted.isFalse().and(mission.ended.isFalse()))
-                .orderBy(mission.participants.size().desc(), mission.createdTime.desc())
-                .fetch();
     }
 
-    @Override
-    public List<Mission> findAllByCreatedInMonth() {
-        return queryFactory
-                .select(mission)
-                .from(mission)
-                .where(mission.deleted.isFalse(), mission.ended.isFalse())
-                .orderBy(mission.createdTime.desc())
-                .fetch();
+    /**
+     * Pageable 요청객체의 사이즈와 비교해서 크다면, true를 리턴한다.
+     * @param missionList
+     * @param pageable
+     * @return
+     */
+    private boolean hasNextPage(List<?> missionList, Pageable pageable){
+        if (missionList.size() > pageable.getPageSize()) {
+            missionList.remove(pageable.getPageSize());
+            return true;
+        }
+        return false;
     }
-    */
+
     @Override
     public List<Mission> findAllByCreatedDate() {
         return queryFactory
@@ -140,6 +131,4 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .orderBy(mission.createdTime.desc())
                 .fetch();
     }
-
-
 }

--- a/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
@@ -200,9 +200,9 @@ public class MissionService {
      */
     @Transactional(readOnly = true)
     @Cacheable(value = "missionLists", key = "'hot-' + 'page-' + #pageable.getPageNumber() + 'size-' + #pageable.getPageSize()")
-    public PageResponseDto findHotList(Pageable pageable){
+    public PageResponseDto findHotList(Pageable pageable, CustomOAuth2User user){
 
-        Slice<MissionHotListResponseDto> responseList = missionRepository.findAllByParticipantSize(pageable);
+        Slice<MissionHotListResponseDto> responseList = missionRepository.findAllByParticipantSize(pageable, user.getId());
 
         PageResponseDto pageResponseDto = new PageResponseDto(responseList.getContent(), responseList.hasNext());
 
@@ -217,9 +217,9 @@ public class MissionService {
      */
     @Transactional(readOnly = true)
     @Cacheable(value = "missionLists", key = "'new-' + 'page-' + #pageable.getPageNumber() + 'size-' + #pageable.getPageSize()")
-    public PageResponseDto findNewList(Pageable pageable){
+    public PageResponseDto findNewList(Pageable pageable, CustomOAuth2User user){
 
-        Slice<MissionNewListResponseDto> responseList = missionRepository.findAllByCreatedInMonth(pageable);
+        Slice<MissionNewListResponseDto> responseList = missionRepository.findAllByCreatedInMonth(pageable, user.getId());
 
         PageResponseDto pageResponseDto = new PageResponseDto(responseList.getContent(), responseList.hasNext());
 

--- a/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
@@ -23,6 +23,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -232,9 +234,13 @@ public class MissionService {
      */
     @Transactional(readOnly = true)
     @Cacheable(value = "missionLists", key = "'all-' + 'page-' + #pageable.getPageNumber() + 'size-' + #pageable.getPageSize()")
-    public PageResponseDto findAllList(Pageable pageable){
+    public PageResponseDto findAllList(Pageable pageable, CustomOAuth2User user){
 
-        Slice<MissionAllListResponseDto> responseList = missionRepository.findAllByCreatedDate(pageable);
+        Slice<MissionAllListResponseDto> responseList = missionRepository.findAllByCreatedDate(pageable, user.getId());
+
+        if (Objects.isNull(responseList)) {
+            responseList = new SliceImpl<>(Collections.emptyList(), pageable, false);
+        }
 
         PageResponseDto pageResponseDto = new PageResponseDto(responseList.getContent(), responseList.hasNext());
 

--- a/src/test/java/dailymissionproject/demo/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/controller/MissionControllerTest.java
@@ -144,7 +144,7 @@ class MissionControllerTest {
                     .endDate(LocalDate.now().plusDays(10))
                     .build();
 
-            when(missionService.findHotList(any())).thenReturn(hotMissionListResponse);
+            when(missionService.findHotList(eq(pageable), any())).thenReturn(hotMissionListResponse);
 
             ResultActions resultActions = mockMvc.perform(get("/api/v1/mission/hot")
                     .param("page", String.valueOf(pageable.getPageNumber()))
@@ -179,7 +179,7 @@ class MissionControllerTest {
                     .build();
 
             //when
-            when(missionService.findNewList(any())).thenReturn(newMissionListResponse);
+            when(missionService.findNewList(eq(pageable), any())).thenReturn(newMissionListResponse);
 
             ResultActions resultActions = mockMvc.perform(get("/api/v1/mission/new")
                     .param("page", String.valueOf(pageable.getPageNumber()))

--- a/src/test/java/dailymissionproject/demo/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/controller/MissionControllerTest.java
@@ -2,26 +2,21 @@ package dailymissionproject.demo.domain.mission.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
+import dailymissionproject.demo.domain.auth.dto.UserDto;
 import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.dto.request.MissionSaveRequestDto;
 import dailymissionproject.demo.domain.mission.dto.request.MissionUpdateRequestDto;
 import dailymissionproject.demo.domain.mission.dto.response.*;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
-import dailymissionproject.demo.domain.mission.exception.MissionExceptionCode;
 import dailymissionproject.demo.domain.mission.fixture.MissionObjectFixture;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.mission.service.MissionService;
 import dailymissionproject.demo.domain.missionRule.dto.MissionRuleResponseDto;
-import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
 import dailymissionproject.demo.domain.participant.dto.response.ParticipantUserDto;
 import dailymissionproject.demo.domain.user.exception.UserException;
 import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.global.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -85,6 +80,12 @@ class MissionControllerTest {
 
     private final Pageable pageable = PageRequest.of(0,3 );
     private final Long missionId = 1L;
+    public static CustomOAuth2User oAuth2User;
+
+    @BeforeEach
+    void setUp(){
+        oAuth2User = CustomOAuth2User.create(new UserDto(1L, "ROLE_USER", "윤성철", "google 1923819273", "sungchul", "aws-s3", "google@gmailcom"));
+    }
 
     @Nested
     @DisplayName("미션 조회 컨트롤러 테스트")
@@ -211,9 +212,9 @@ class MissionControllerTest {
                     .startDate(LocalDate.now().minusDays(10))
                     .endDate(LocalDate.now().plusDays(10))
                     .build();
-            //when
-            when(missionService.findAllList(any())).thenReturn(allMissionListResponse);
 
+            //when
+            when(missionService.findAllList(eq(pageable), any())).thenReturn(allMissionListResponse);
             ResultActions resultActions = mockMvc.perform(get("/api/v1/mission/all")
                             .param("page", String.valueOf(pageable.getPageNumber()))
                             .param("size", String.valueOf(pageable.getPageSize()))

--- a/src/test/java/dailymissionproject/demo/domain/mission/fixture/MissionObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/fixture/MissionObjectFixture.java
@@ -323,6 +323,7 @@ public class MissionObjectFixture {
                 .nickname("yoonsu")
                 .startDate(LocalDate.now().minusDays(10))
                 .endDate(LocalDate.now().plusDays(10))
+                .participating(true)
                 .build();
 
         MissionAllListResponseDto allMission_2 = MissionAllListResponseDto.builder()
@@ -333,6 +334,7 @@ public class MissionObjectFixture {
                 .nickname("sungchul")
                 .startDate(LocalDate.now().minusDays(7))
                 .endDate(LocalDate.now().plusDays(7))
+                .participating(true)
                 .build();
 
         List<MissionAllListResponseDto> listResponse = List.of(allMission_1, allMission_2);

--- a/src/test/java/dailymissionproject/demo/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/service/MissionServiceTest.java
@@ -15,7 +15,6 @@ import dailymissionproject.demo.domain.mission.repository.MissionRepository;
 import dailymissionproject.demo.domain.missionRule.dto.MissionRuleResponseDto;
 import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
 import dailymissionproject.demo.domain.participant.dto.response.ParticipantUserDto;
-import dailymissionproject.demo.domain.participant.repository.Participant;
 import dailymissionproject.demo.domain.participant.repository.ParticipantRepository;
 import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
@@ -26,7 +25,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
@@ -34,8 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -150,9 +148,9 @@ class MissionServiceTest {
             @Test
             @DisplayName("전체 미션 리스트를 조회할 수 있다.")
             void test_mission_read_all_list_success() {
-                when(missionRepository.findAllByCreatedDate(pageable)).thenReturn(MissionObjectFixture.getAllMissionListPageable());
+                when(missionRepository.findAllByCreatedDate(pageable, anyLong())).thenReturn(MissionObjectFixture.getAllMissionListPageable());
 
-                PageResponseDto pageResponseDto = missionService.findAllList(pageable);
+                PageResponseDto pageResponseDto = missionService.findAllList(pageable, oAuth2User);
                 List<MissionAllListResponseDto> list = (List<MissionAllListResponseDto>) pageResponseDto.content();
 
                 assertEquals(list.get(0).getTitle(),

--- a/src/test/java/dailymissionproject/demo/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/service/MissionServiceTest.java
@@ -124,9 +124,9 @@ class MissionServiceTest {
             @Test
             @DisplayName("인기 미션 리스트를 조회할 수 있다.")
             void test_mission_read_hot_list_success() {
-                when(missionRepository.findAllByParticipantSize(pageable)).thenReturn(MissionObjectFixture.getHotMissionListPageable());
+                when(missionRepository.findAllByParticipantSize(pageable, anyLong())).thenReturn(MissionObjectFixture.getHotMissionListPageable());
 
-                PageResponseDto pageResponseDto = missionService.findHotList(pageable);
+                PageResponseDto pageResponseDto = missionService.findHotList(pageable, oAuth2User);
                 List<MissionHotListResponseDto> list = (List<MissionHotListResponseDto>) pageResponseDto.content();
 
                 assertEquals(list.get(0).getTitle(),
@@ -136,9 +136,9 @@ class MissionServiceTest {
             @Test
             @DisplayName("신규 미션 리스트를 조회할 수 있다.")
             void test_mission_read_new_list_success() {
-                when(missionRepository.findAllByCreatedInMonth(pageable)).thenReturn(MissionObjectFixture.getNewMissionListPageable());
+                when(missionRepository.findAllByCreatedInMonth(pageable, anyLong())).thenReturn(MissionObjectFixture.getNewMissionListPageable());
 
-                PageResponseDto pageResponseDto = missionService.findNewList(pageable);
+                PageResponseDto pageResponseDto = missionService.findNewList(pageable, oAuth2User);
                 List<MissionNewListResponseDto> list = (List<MissionNewListResponseDto>) pageResponseDto.content();
 
                 assertEquals(list.get(0).getTitle(),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #73        

## 📝작업 내용

> 미션 리스트를 조회할 때, 사용자가 참여중인지 알 수 있게 API를 수정한다.
- participaiting 필드 추가 (boolean)
- 조회 쿼리에 검증 로직 추가
- 테스트 코드 작성