### PR TITLE
Pr/78/post 수정

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostDetailResponseDto.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @Schema(description = "포스트 상세 응답 DTO")
-public class PostResponseDto {
+public class PostDetailResponseDto {
 
     @Schema(description = "포스트 PK ID")
     private Long id;
@@ -51,7 +51,7 @@ public class PostResponseDto {
     private LocalDateTime modifiedDate;
 
     @Builder
-    public PostResponseDto (Post post){
+    public PostDetailResponseDto(Post post){
         this.id = post.getId();
         this.missionId = post.getMission().getId();
         this.missionTitle = post.getMission().getTitle();
@@ -65,8 +65,8 @@ public class PostResponseDto {
     }
 
     @Builder
-    public PostResponseDto(Long id, Long missionId, String missionTitle, String nickname, String userImageUrl, String title
-                        ,String content, String imageUrl, LocalDateTime createdDate, LocalDateTime modifiedDate){
+    public PostDetailResponseDto(Long id, Long missionId, String missionTitle, String nickname, String userImageUrl, String title
+                        , String content, String imageUrl, LocalDateTime createdDate, LocalDateTime modifiedDate){
         this.id = id;
         this.missionId = missionId;
         this.missionTitle = missionTitle;
@@ -77,5 +77,9 @@ public class PostResponseDto {
         this.imageUrl = imageUrl;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
+    }
+
+    public static PostDetailResponseDto from(Post post){
+        return new PostDetailResponseDto(post);
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostDetailResponseDto.java
@@ -14,41 +14,41 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
 @Schema(description = "포스트 상세 응답 DTO")
 public class PostDetailResponseDto {
 
     @Schema(description = "포스트 PK ID")
-    private Long id;
+    private final Long id;
 
     @Schema(description = "포스트 미션 ID")
-    private Long missionId;
+    private final Long missionId;
 
     @Schema(description = "포스트 미션 제목")
-    private String missionTitle;
+    private final String missionTitle;
 
     @Schema(description = "포스트 작성자 닉네임")
-    private String nickname;
+    private final String nickname;
 
     @Schema(description = "포스트 작성자 이미지")
-    private String userImageUrl;
+    private final String userImageUrl;
 
     @Schema(description = "포스트 제목")
-    private String title;
+    private final String title;
     @Schema(description = "포스트 내용")
-    private String content;
+    private final String content;
     @Schema(description = "포스트 썸네일")
-    private String imageUrl;
+    private final String imageUrl;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime createdDate;
+    private final LocalDateTime createdDate;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime modifiedDate;
+    private final LocalDateTime modifiedDate;
 
     @Builder
     public PostDetailResponseDto(Post post){
@@ -65,8 +65,7 @@ public class PostDetailResponseDto {
     }
 
     @Builder
-    public PostDetailResponseDto(Long id, Long missionId, String missionTitle, String nickname, String userImageUrl, String title
-                        , String content, String imageUrl, LocalDateTime createdDate, LocalDateTime modifiedDate){
+    public PostDetailResponseDto(Long id, Long missionId, String missionTitle, String nickname, String userImageUrl, String title, String content, String imageUrl, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.missionId = missionId;
         this.missionTitle = missionTitle;
@@ -78,6 +77,7 @@ public class PostDetailResponseDto {
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
     }
+
 
     public static PostDetailResponseDto from(Post post){
         return new PostDetailResponseDto(post);

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostMissionListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostMissionListResponseDto.java
@@ -1,0 +1,60 @@
+package dailymissionproject.demo.domain.post.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "미션별 포스트 리스트 응답 DTO")
+@NoArgsConstructor(force = true)
+public class PostMissionListResponseDto {
+    @Schema(description = "포스트 PK ID")
+    private final Long id;
+
+    @Schema(description = "포스트 미션 ID")
+    private final Long missionId;
+
+    @Schema(description = "포스트 작성자 닉네임")
+    private final String nickname;
+
+    @Schema(description = "포스트 작성자 이미지")
+    private final String userImageUrl;
+
+    @Schema(description = "포스트 제목")
+    private final String title;
+    @Schema(description = "포스트 내용")
+    private final String content;
+    @Schema(description = "포스트 썸네일")
+    private final String imageUrl;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime createdDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime modifiedDate;
+
+    @Builder
+    public PostMissionListResponseDto(Long id, Long missionId, String nickname, String userImageUrl, String title, String content, String imageUrl, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+        this.id = id;
+        this.missionId = missionId;
+        this.nickname = nickname;
+        this.userImageUrl = userImageUrl;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostUserListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostUserListResponseDto.java
@@ -1,9 +1,16 @@
 package dailymissionproject.demo.domain.post.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Schema(description = "유저별 포스트 리스트 응답 DTO")
@@ -26,13 +33,26 @@ public class PostUserListResponseDto {
     @Schema(description = "포스트 썸네일")
     private final String imageUrl;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime createdDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime modifiedDate;
+
     @Builder
-    public PostUserListResponseDto(Long id, Long missionId, String missionTitle, String title, String content, String imageUrl) {
+    public PostUserListResponseDto(Long id, Long missionId, String missionTitle, String title, String content, String imageUrl
+    , LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.missionId = missionId;
         this.missionTitle = missionTitle;
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostUserListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostUserListResponseDto.java
@@ -1,0 +1,38 @@
+package dailymissionproject.demo.domain.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "유저별 포스트 리스트 응답 DTO")
+@NoArgsConstructor(force = true)
+public class PostUserListResponseDto {
+
+    @Schema(description = "포스트 PK ID")
+    private final Long id;
+
+    @Schema(description = "포스트 미션 ID")
+    private final Long missionId;
+
+    @Schema(description = "포스트 미션 제목")
+    private final String missionTitle;
+
+    @Schema(description = "포스트 제목")
+    private final String title;
+    @Schema(description = "포스트 내용")
+    private final String content;
+    @Schema(description = "포스트 썸네일")
+    private final String imageUrl;
+
+    @Builder
+    public PostUserListResponseDto(Long id, Long missionId, String missionTitle, String title, String content, String imageUrl) {
+        this.id = id;
+        this.missionId = missionId;
+        this.missionTitle = missionTitle;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustom.java
@@ -2,7 +2,7 @@ package dailymissionproject.demo.domain.post.repository;
 
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.post.dto.PostSubmitDto;
-import dailymissionproject.demo.domain.post.dto.response.PostDetailResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostMissionListResponseDto;
 import dailymissionproject.demo.domain.post.dto.response.PostUserListResponseDto;
 import dailymissionproject.demo.domain.user.repository.User;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +20,7 @@ public interface PostRepositoryCustom {
 
     Slice<PostUserListResponseDto> findAllByUser(Pageable pageable, User user);
 
-    Slice<PostDetailResponseDto> findAllByMission(Pageable pageable, Mission mission);
+    Slice<PostMissionListResponseDto> findAllByMission(Pageable pageable, Mission mission);
 
     //List<Post> findAllByUser(User user);
 

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustom.java
@@ -2,7 +2,8 @@ package dailymissionproject.demo.domain.post.repository;
 
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.post.dto.PostSubmitDto;
-import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostDetailResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostUserListResponseDto;
 import dailymissionproject.demo.domain.user.repository.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,9 +18,9 @@ public interface PostRepositoryCustom {
 
     List<Post> findAll();
 
-    Slice<PostResponseDto> findAllByUser(Pageable pageable, User user);
+    Slice<PostUserListResponseDto> findAllByUser(Pageable pageable, User user);
 
-    Slice<PostResponseDto> findAllByMission(Pageable pageable, Mission mission);
+    Slice<PostDetailResponseDto> findAllByMission(Pageable pageable, Mission mission);
 
     //List<Post> findAllByUser(User user);
 

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
@@ -64,7 +64,9 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 post.mission.title,
                 post.title,
                 post.content,
-                post.imageUrl))
+                post.imageUrl,
+                post.createdTime,
+                post.modifiedDate))
                 .from(post)
                 .where(post.user.eq(user).and(post.deleted.isFalse()))
                 .offset(pageable.getOffset())

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
@@ -130,8 +130,12 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .fetch();
     }
 
-    //==미션별 Weekly 포스트 제출 이력을 postSubmitDto 객체로 전달받는다==//
-    //새벽 3시 이전 제출은 전날 제출로 변환
+    /**
+     * 미션별 Weekly 포스트 제출 이력을 PostSubmitDto로 응답한다.
+     * @param id
+     * @param startDate
+     * @return
+     */
     @Override
     public List<PostSubmitDto> findWeeklyPostSubmitByMission(Long id, LocalDate startDate) {
 

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
@@ -157,9 +157,15 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .fetch();
     }
 
-
-    //==금일 해당 미션에 제출 이력이 있는지 확인//
-    //삭제된 포스트는 제출하지 않은 것으로 간주
+    /**
+     * 금일 포스트를 제출이력을 검증하는 메서드
+     * 삭제된 포스트는 제출하지 않은 것으로 간주한다.
+     * @param mission
+     * @param user
+     * @param startDate
+     * @param endDate
+     * @return
+     */
     @Override
     public Long countPostSubmit(Mission mission, User user, LocalDateTime startDate, LocalDateTime endDate) {
         return queryFactory

--- a/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
@@ -9,8 +9,10 @@ import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.exception.MissionExceptionCode;
 import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
 import dailymissionproject.demo.domain.post.dto.request.PostUpdateRequestDto;
-import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostDetailResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostMissionListResponseDto;
 import dailymissionproject.demo.domain.post.dto.response.PostUpdateResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostUserListResponseDto;
 import dailymissionproject.demo.domain.post.exception.PostException;
 import dailymissionproject.demo.domain.post.exception.PostExceptionCode;
 import dailymissionproject.demo.domain.post.fixture.PostObjectFixture;
@@ -61,9 +63,9 @@ class PostControllerTest {
     private PostService postService;
 
     private final PostSaveRequestDto saveRequest = PostObjectFixture.getSaveRequest();
-    private final PostResponseDto detailResponse = PostObjectFixture.getDetailResponse();
-    private final List<PostResponseDto> userPostList = PostObjectFixture.getUserPostList();
-    private final List<PostResponseDto> missionPostList = PostObjectFixture.getMissionPostList();
+    private final PostDetailResponseDto detailResponse = PostObjectFixture.getDetailResponse();
+    private final List<PostUserListResponseDto> userPostList = PostObjectFixture.getUserPostList();
+    private final List<PostMissionListResponseDto> missionPostList = PostObjectFixture.getMissionPostList();
     private final PostUpdateRequestDto updateRequest = PostObjectFixture.getPostUpdateRequest();
     private final PostUpdateResponseDto updateResponse = PostObjectFixture.getPostUpdateResponse();
 
@@ -183,7 +185,7 @@ class PostControllerTest {
         void post_read_user_list_success() throws Exception {
             //given
             Pageable pageable = PageRequest.of(0, 3);
-            Slice<PostResponseDto> sliceList = new SliceImpl<>(userPostList, pageable, false);
+            Slice<PostUserListResponseDto> sliceList = new SliceImpl<>(userPostList, pageable, false);
             PageResponseDto response = new PageResponseDto<>(sliceList, false);
 
             when(postService.findAllByUser(any(), any())).thenReturn(response);
@@ -216,7 +218,7 @@ class PostControllerTest {
         void post_read_mission_list_success() throws Exception {
             //given
             Pageable pageable = PageRequest.of(0, 3);
-            Slice<PostResponseDto> sliceList = new SliceImpl<>(missionPostList, pageable, false);
+            Slice<PostMissionListResponseDto> sliceList = new SliceImpl<>(missionPostList, pageable, false);
             PageResponseDto response = new PageResponseDto<>(sliceList, false);
 
             when(postService.findAllByMission(any(), any())).thenReturn(response);

--- a/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,4 @@
+package dailymissionproject.demo.domain.post.controller;
+
+public class PostControllerTest {
+}

--- a/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
@@ -3,22 +3,33 @@ package dailymissionproject.demo.domain.post.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.auth.dto.UserDto;
+import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.exception.MissionExceptionCode;
 import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
 import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.exception.PostException;
+import dailymissionproject.demo.domain.post.exception.PostExceptionCode;
 import dailymissionproject.demo.domain.post.fixture.PostObjectFixture;
 import dailymissionproject.demo.domain.post.service.PostService;
+import dailymissionproject.demo.domain.user.exception.UserException;
+import dailymissionproject.demo.domain.user.exception.UserExceptionCode;
 import dailymissionproject.demo.global.WithMockCustomUser;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -45,8 +56,12 @@ class PostControllerTest {
 
     private final PostSaveRequestDto saveRequest = PostObjectFixture.getSaveRequest();
     private final PostResponseDto detailResponse = PostObjectFixture.getDetailResponse();
+    private final List<PostResponseDto> userPostList = PostObjectFixture.getUserPostList();
+    private final List<PostResponseDto> missionPostList = PostObjectFixture.getMissionPostList();
 
-    private static CustomOAuth2User oAuth2User;
+    public static CustomOAuth2User oAuth2User;
+    private final Long missionId = 1L;
+    private final Long postId = 1L;
 
     @BeforeEach
     void setUp() {
@@ -101,5 +116,104 @@ class PostControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("포스트 조회 컨트롤러 테스트")
+    class PostReadControllerTest {
 
+        @Test
+        @DisplayName("포스트를 상세조회할 수 있다.")
+        void post_read_success() throws Exception {
+            when(postService.findById(postId)).thenReturn(detailResponse);
+
+            ResultActions resultActions = mockMvc.perform(get("/api/v1/post/{id}", postId)
+                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            resultActions.andExpect(jsonPath("$.success").value(true));
+            resultActions.andExpect(jsonPath("$.data.title").value(detailResponse.getTitle()));
+            resultActions.andExpect(jsonPath("$.data.content").value(detailResponse.getContent()));
+            resultActions.andExpect(jsonPath("$.data.missionTitle").value(detailResponse.getMissionTitle()));
+            resultActions.andExpect(jsonPath("$.data.imageUrl").value(detailResponse.getImageUrl()));
+        }
+
+        @Test
+        @DisplayName("포스트가 존재하지 않으면 포스트를 조회할 수 없다.")
+        void post_read_fail_when_post_not_exists() throws Exception {
+            when(postService.findById(postId)).thenThrow(new PostException(PostExceptionCode.POST_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/post/{id}", postId)
+                    .with(csrf()))
+                    .andExpect(status().isBadRequest());
+
+            verify(postService, description("findById 메서드가 정상적으로 호출됨"))
+                    .findById(postId);
+        }
+
+        @Test
+        @DisplayName("유저가 작성한 포스트 전체를 조회할 수 있다.")
+        void post_read_user_list_success() throws Exception {
+            //given
+            Pageable pageable = PageRequest.of(0, 3);
+            Slice<PostResponseDto> sliceList = new SliceImpl<>(userPostList, pageable, false);
+            PageResponseDto response = new PageResponseDto<>(sliceList, false);
+
+            when(postService.findAllByUser(any(), any())).thenReturn(response);
+
+            ResultActions resultActions = mockMvc.perform(get("/api/v1/post/user")
+                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            resultActions.andExpect(jsonPath("$.success").value(true));
+            resultActions.andExpect(jsonPath("$.data.content[0].content").value(userPostList.get(0).getContent()));
+            resultActions.andExpect(jsonPath("$.data.content[0].title").value(userPostList.get(0).getTitle()));
+        }
+
+        @Test
+        @DisplayName("유저 정보가 없을경우 예외를 반환한다.")
+        void post_read_user_list_fail_when_user_not_exits() throws Exception {
+            when(postService.findAllByUser(any(), any())).thenThrow(new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/post/user")
+                    .with(csrf()))
+                    .andExpect(status().isBadRequest());
+
+            verify(postService, description("findAllByUser 메서드가 정상 호출됨"))
+                    .findAllByUser(any(), any());
+        }
+
+        @Test
+        @DisplayName("미션별 작성된 포스트 전체를 조회할 수 있다.")
+        void post_read_mission_list_success() throws Exception {
+            //given
+            Pageable pageable = PageRequest.of(0, 3);
+            Slice<PostResponseDto> sliceList = new SliceImpl<>(missionPostList, pageable, false);
+            PageResponseDto response = new PageResponseDto<>(sliceList, false);
+
+            when(postService.findAllByMission(any(), any())).thenReturn(response);
+
+            ResultActions resultActions = mockMvc.perform(get("/api/v1/post/mission/{id}", missionId)
+                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            resultActions.andExpect(jsonPath("$.success").value(true));
+            resultActions.andExpect(jsonPath("$.data.content[0].content").value(missionPostList.get(0).getContent()));
+            resultActions.andExpect(jsonPath("$.data.content[0].title").value(missionPostList.get(0).getTitle()));
+        }
+
+        @Test
+        @DisplayName("미션 정보가 없을경우 예외를 반환한다.")
+        void post_read_mission_list_fail_when_mission_not_exits() throws Exception {
+            when(postService.findAllByMission(any(), any())).thenThrow(new MissionException(MissionExceptionCode.MISSION_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/post/mission/{id}", missionId)
+                    .with(csrf()))
+                    .andExpect(status().isBadRequest());
+
+            verify(postService, description("findAllByMission 메서드가 정상 호출됨"))
+                    .findAllByMission(any(), any());
+        }
+    }
 }

--- a/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
@@ -1,4 +1,105 @@
 package dailymissionproject.demo.domain.post.controller;
 
-public class PostControllerTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
+import dailymissionproject.demo.domain.auth.dto.UserDto;
+import dailymissionproject.demo.domain.mission.exception.MissionException;
+import dailymissionproject.demo.domain.mission.exception.MissionExceptionCode;
+import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
+import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.fixture.PostObjectFixture;
+import dailymissionproject.demo.domain.post.service.PostService;
+import dailymissionproject.demo.global.WithMockCustomUser;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+
+@Tag("unit")
+@DisplayName("[unit] [controller] PostController")
+@WebMvcTest(controllers = PostController.class)
+@WithMockCustomUser
+class PostControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private PostService postService;
+
+    private final PostSaveRequestDto saveRequest = PostObjectFixture.getSaveRequest();
+    private final PostResponseDto detailResponse = PostObjectFixture.getDetailResponse();
+
+    private static CustomOAuth2User oAuth2User;
+
+    @BeforeEach
+    void setUp() {
+        oAuth2User = CustomOAuth2User.create(new UserDto(1L, "ROLE_USER", "윤성철", "google 1923819273", "sungchul", "aws-s3", "google@gmailcom"));
+    }
+
+    @Nested
+    @DisplayName("포스트 생성 컨트롤러 테스트")
+    class PostSaveControllerTest {
+        final String fileName = "https://AWS-S3/postThumbnail.jpg";
+        final String contentType = "image/jpeg";
+
+        @Test
+        @DisplayName("포스트를 생성 할 수 있다.")
+        void post_save_success() throws Exception {
+            MockMultipartFile file = new MockMultipartFile("file", fileName, contentType
+                    , "test data".getBytes(StandardCharsets.UTF_8));
+            MockMultipartFile request = new MockMultipartFile("postSaveReqDto", "request.json",
+                    "application/json", objectMapper.writeValueAsBytes(saveRequest));
+
+            when(postService.save(any(CustomOAuth2User.class), eq(saveRequest), eq(file))).thenReturn(1L);
+
+            mockMvc.perform(multipart(HttpMethod.POST, "/api/v1/post/save")
+                    .file(file)
+                    .file(request)
+                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            verify(postService, description("save 메서드가 정상적으로 호출됨"))
+                    .save(any(), any(PostSaveRequestDto.class), any());
+        }
+
+        @Test
+        @DisplayName("포스트 생성에 실패한다.")
+        void post_save_fail() throws Exception {
+            MockMultipartFile file = new MockMultipartFile("file", fileName, contentType
+                    , "test data".getBytes(StandardCharsets.UTF_8));
+            MockMultipartFile request = new MockMultipartFile("postSaveReqDto", "request.json", "application/json"
+            , objectMapper.writeValueAsBytes(saveRequest));
+
+            when(postService.save(any(), any(), any())).thenThrow(new MissionException(MissionExceptionCode.MISSION_NOT_FOUND));
+
+            mockMvc.perform(multipart(HttpMethod.POST, "/api/v1/post/save")
+                    .file(file)
+                    .file(request)
+                    .with(csrf()))
+                    .andExpect(status().isBadRequest());
+
+            verify(postService, description("save 메서드가 정상적으로 호출됨"))
+                    .save(any(CustomOAuth2User.class), any(), any());
+        }
+    }
+
+
 }

--- a/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
@@ -9,6 +9,8 @@ import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
 import dailymissionproject.demo.domain.post.repository.Post;
 import dailymissionproject.demo.domain.user.repository.Role;
 import dailymissionproject.demo.domain.user.repository.User;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
@@ -94,5 +96,66 @@ public class PostObjectFixture {
         return PostResponseDto.builder()
                 .post(getPostFixture())
                 .build();
+    }
+
+    public static List<PostResponseDto> getUserPostList(){
+        User user =  new User(1L, "윤성철", "google@gamil.com", "sungchul");
+
+        Post post_1 = Post.builder()
+                .user(user)
+                .mission(getMissionFixture())
+                .title("TITLE1")
+                .content("CONTENT1")
+                .imgUrl("IMAGE1")
+                .build();
+
+        Post post_2 = Post.builder()
+                .user(user)
+                .mission(getMissionFixture())
+                .title("TITLE2")
+                .content("CONTENT2")
+                .imgUrl("IMAGE2")
+                .build();
+
+        PostResponseDto postResponse_1 = PostResponseDto.builder()
+                .post(post_1)
+                .build();
+
+        PostResponseDto postResponse_2 = PostResponseDto.builder()
+                .post(post_2)
+                .build();
+
+        return List.of(postResponse_1, postResponse_2);
+    }
+
+    public static List<PostResponseDto> getMissionPostList(){
+        Mission mission = new Mission(1L, getUserFixture(), "MISSION_TITLE", "MISSION_CONTENT"
+                , "IMAGEURL", LocalDate.now(), LocalDate.now());
+
+        Post post_1 = Post.builder()
+                .user(getUserFixture())
+                .mission(mission)
+                .title("TITLE1")
+                .content("CONTENT1")
+                .imgUrl("IMAGE1")
+                .build();
+
+        Post post_2 = Post.builder()
+                .user(getUserFixture())
+                .mission(mission)
+                .title("TITLE2")
+                .content("CONTENT2")
+                .imgUrl("IMAGE2")
+                .build();
+
+        PostResponseDto postResponse_1 = PostResponseDto.builder()
+                .post(post_1)
+                .build();
+
+        PostResponseDto postResponse_2 = PostResponseDto.builder()
+                .post(post_2)
+                .build();
+
+        return List.of(postResponse_1, postResponse_2);
     }
 }

--- a/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
@@ -1,0 +1,4 @@
+package dailymissionproject.demo.domain.post.fixture;
+
+public class PostObjectFixture {
+}

--- a/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
@@ -6,8 +6,10 @@ import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
 import dailymissionproject.demo.domain.missionRule.repository.Week;
 import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
 import dailymissionproject.demo.domain.post.dto.request.PostUpdateRequestDto;
-import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostDetailResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostMissionListResponseDto;
 import dailymissionproject.demo.domain.post.dto.response.PostUpdateResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostUserListResponseDto;
 import dailymissionproject.demo.domain.post.repository.Post;
 import dailymissionproject.demo.domain.user.repository.Role;
 import dailymissionproject.demo.domain.user.repository.User;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class PostObjectFixture {
@@ -94,41 +97,37 @@ public class PostObjectFixture {
      * Post 상세조회 fixture를 반환한다.
      * @return PostResponseDto
      */
-    public static PostResponseDto getDetailResponse(){
-        return PostResponseDto.builder()
-                .post(getPostFixture())
-                .build();
+    public static PostDetailResponseDto getDetailResponse(){
+        return PostDetailResponseDto.from(getPostFixture());
     }
 
     /**
      * 유저가 작성한 포스트 리스트 fixture를 반환한다.
      * @return
      */
-    public static List<PostResponseDto> getUserPostList(){
+    public static List<PostUserListResponseDto> getUserPostList(){
         User user =  new User(1L, "윤성철", "google@gamil.com", "sungchul");
 
-        Post post_1 = Post.builder()
-                .user(user)
-                .mission(getMissionFixture())
+        PostUserListResponseDto postResponse_1 = PostUserListResponseDto.builder()
+                .id(1L)
                 .title("TITLE1")
                 .content("CONTENT1")
-                .imgUrl("IMAGE1")
+                .imageUrl("IMAGE1")
+                .missionId(getMissionFixture().getId())
+                .missionTitle(getMissionFixture().getTitle())
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
                 .build();
 
-        Post post_2 = Post.builder()
-                .user(user)
-                .mission(getMissionFixture())
+        PostUserListResponseDto postResponse_2 = PostUserListResponseDto.builder()
+                .id(2L)
                 .title("TITLE2")
                 .content("CONTENT2")
-                .imgUrl("IMAGE2")
-                .build();
-
-        PostResponseDto postResponse_1 = PostResponseDto.builder()
-                .post(post_1)
-                .build();
-
-        PostResponseDto postResponse_2 = PostResponseDto.builder()
-                .post(post_2)
+                .imageUrl("IMAGE2")
+                .missionId(getMissionFixture().getId())
+                .missionTitle(getMissionFixture().getTitle())
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
                 .build();
 
         return List.of(postResponse_1, postResponse_2);
@@ -138,35 +137,31 @@ public class PostObjectFixture {
      * 미션별로 작성된 포스트 리스트를 반환한다.
      * @return
      */
-    public static List<PostResponseDto> getMissionPostList(){
+    public static List<PostMissionListResponseDto> getMissionPostList(){
         Mission mission = new Mission(1L, getUserFixture(), "MISSION_TITLE", "MISSION_CONTENT"
                 , "IMAGEURL", LocalDate.now(), LocalDate.now());
 
-        Post post_1 = Post.builder()
-                .user(getUserFixture())
-                .mission(mission)
+        PostMissionListResponseDto post_1 = PostMissionListResponseDto.builder()
+                .missionId(getMissionFixture().getId())
+                .id(1L)
                 .title("TITLE1")
                 .content("CONTENT1")
-                .imgUrl("IMAGE1")
+                .imageUrl("IMAGEURL1")
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
                 .build();
 
-        Post post_2 = Post.builder()
-                .user(getUserFixture())
-                .mission(mission)
+        PostMissionListResponseDto post_2 = PostMissionListResponseDto.builder()
+                .id(2L)
+                .missionId(getMissionFixture().getId())
                 .title("TITLE2")
                 .content("CONTENT2")
-                .imgUrl("IMAGE2")
+                .imageUrl("IMAGEURL2")
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
                 .build();
 
-        PostResponseDto postResponse_1 = PostResponseDto.builder()
-                .post(post_1)
-                .build();
-
-        PostResponseDto postResponse_2 = PostResponseDto.builder()
-                .post(post_2)
-                .build();
-
-        return List.of(postResponse_1, postResponse_2);
+        return List.of(post_1, post_2);
     }
 
     public static PostUpdateRequestDto getPostUpdateRequest(){

--- a/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
@@ -5,7 +5,9 @@ import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
 import dailymissionproject.demo.domain.missionRule.repository.Week;
 import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
+import dailymissionproject.demo.domain.post.dto.request.PostUpdateRequestDto;
 import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.dto.response.PostUpdateResponseDto;
 import dailymissionproject.demo.domain.post.repository.Post;
 import dailymissionproject.demo.domain.user.repository.Role;
 import dailymissionproject.demo.domain.user.repository.User;
@@ -98,6 +100,10 @@ public class PostObjectFixture {
                 .build();
     }
 
+    /**
+     * 유저가 작성한 포스트 리스트 fixture를 반환한다.
+     * @return
+     */
     public static List<PostResponseDto> getUserPostList(){
         User user =  new User(1L, "윤성철", "google@gamil.com", "sungchul");
 
@@ -128,6 +134,10 @@ public class PostObjectFixture {
         return List.of(postResponse_1, postResponse_2);
     }
 
+    /**
+     * 미션별로 작성된 포스트 리스트를 반환한다.
+     * @return
+     */
     public static List<PostResponseDto> getMissionPostList(){
         Mission mission = new Mission(1L, getUserFixture(), "MISSION_TITLE", "MISSION_CONTENT"
                 , "IMAGEURL", LocalDate.now(), LocalDate.now());
@@ -157,5 +167,20 @@ public class PostObjectFixture {
                 .build();
 
         return List.of(postResponse_1, postResponse_2);
+    }
+
+    public static PostUpdateRequestDto getPostUpdateRequest(){
+        return PostUpdateRequestDto.builder()
+                .title("TITLE")
+                .content("CONTENT")
+                .build();
+    }
+
+    public static PostUpdateResponseDto getPostUpdateResponse(){
+        return PostUpdateResponseDto.builder()
+                .title("TITLE")
+                .content("CONTENT")
+                .imageUrl("IMAGE")
+                .build();
     }
 }

--- a/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
@@ -1,4 +1,98 @@
 package dailymissionproject.demo.domain.post.fixture;
 
+import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
+import dailymissionproject.demo.domain.mission.repository.Mission;
+import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
+import dailymissionproject.demo.domain.missionRule.repository.Week;
+import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
+import dailymissionproject.demo.domain.post.dto.response.PostResponseDto;
+import dailymissionproject.demo.domain.post.repository.Post;
+import dailymissionproject.demo.domain.user.repository.Role;
+import dailymissionproject.demo.domain.user.repository.User;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDate;
+import java.util.List;
+
 public class PostObjectFixture {
+
+    /**
+     * 유저 엔티티 fixture를 반환한다.
+     * @return User
+     */
+    public static User getUserFixture(){
+        return User.builder()
+                .username("google 1923819273")
+                .email("google@gmail.com")
+                .nickname("sungchul")
+                .imageUrl("https://aws-s3.jpg")
+                .name("윤성철")
+                .role(Role.USER)
+                .build();
+    }
+
+    /**
+     * 미션규칙 엔티티 fixture를 반환합니다.
+     * @return MissionRule
+     */
+    public static MissionRule getMissionRuleFixture(){
+        return MissionRule.builder()
+                .week(new Week(false, true, true, true, true, true, false))
+                .build();
+    }
+
+    /**
+     * Mission 엔티티 fixture를 반환한다.
+     * @return Mission
+     */
+    public static Mission getMissionFixture(){
+        return Mission.builder()
+                .title("TITLE")
+                .content("CONTENT")
+                .imageUrl("THUMBNAIL.jpg")
+                .hint("HINT")
+                .credential("CREDENTIAL")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(10))
+                .user(getUserFixture())
+                .missionRule(getMissionRuleFixture())
+                .build();
+    }
+
+    /**
+     * Post 엔티티 fixture를 반환한다.
+     * @return Post
+     */
+    public static Post getPostFixture(){
+        return Post.builder()
+                .mission(getMissionFixture())
+                .user(getUserFixture())
+                .title("TITLE")
+                .content("CONTENT")
+                .imgUrl("IMAGE")
+                .build();
+    }
+
+    /**
+     * Post 생성 요청 fixture를 반환한다.
+     * @return PostSaveRequestDto
+     */
+    public static PostSaveRequestDto getSaveRequest(){
+        return PostSaveRequestDto.builder()
+                .missionId(1L)
+                .title("TITLE")
+                .content("CONTENT")
+                .build();
+    }
+
+    /**
+     * Post 상세조회 fixture를 반환한다.
+     * @return PostResponseDto
+     */
+    public static PostResponseDto getDetailResponse(){
+        return PostResponseDto.builder()
+                .post(getPostFixture())
+                .build();
+    }
 }

--- a/src/test/java/dailymissionproject/demo/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/repository/PostRepositoryTest.java
@@ -1,0 +1,4 @@
+package dailymissionproject.demo.domain.post.repository;
+
+public class PostRepositoryTest {
+}

--- a/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
@@ -1,0 +1,4 @@
+package dailymissionproject.demo.domain.post.service;
+
+public class PostServiceTest {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #78         

## 📝작업 내용

> 도메인 POST에 대한 리팩토링을 수행한다.
- 기존 PostResponseDTO -> `PostDetailResonseDto`, `PostUserListResponseDto`, `PostMissionListResposneDto` 분리
- 유저별 포스트 리스트가 없을 경우 Exception -> status 200, null 응답으로 비즈니스 로직 변경
- PostRepositoryCustomImpl 미션, 유저별 조회 쿼리 -> hasNextPage, fetchAll()로 메서드를 분리하고, findAll() 메서드에서 호출하여 Slice 객체로 응답 처리
- 비즈니스 로직중 포스트 수정, 기존의 null 검증 로직을 stream Optional.ofNullable()을 도입하여 리팩토링