### PR TITLE
Pr/94/푸시 알림 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+	//kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	//QueryDsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/generated/dailymissionproject/demo/domain/notify/repository/QNotification.java
+++ b/src/main/generated/dailymissionproject/demo/domain/notify/repository/QNotification.java
@@ -1,0 +1,67 @@
+package dailymissionproject.demo.domain.notify.repository;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = -1691128655L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final dailymissionproject.demo.common.repository.QBaseTimeEntity _super = new dailymissionproject.demo.common.repository.QBaseTimeEntity(this);
+
+    public final BooleanPath checked = createBoolean("checked");
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdTime = _super.createdTime;
+
+    public final BooleanPath deleted = createBoolean("deleted");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedTime = _super.lastModifiedTime;
+
+    public final EnumPath<NotificationType> notificationType = createEnum("notificationType", NotificationType.class);
+
+    public final dailymissionproject.demo.domain.user.repository.QUser receiver;
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.receiver = inits.isInitialized("receiver") ? new dailymissionproject.demo.domain.user.repository.QUser(forProperty("receiver")) : null;
+    }
+
+}
+

--- a/src/main/generated/dailymissionproject/demo/domain/user/repository/QUser.java
+++ b/src/main/generated/dailymissionproject/demo/domain/user/repository/QUser.java
@@ -40,6 +40,8 @@ public class QUser extends EntityPathBase<User> {
 
     public final StringPath nickname = createString("nickname");
 
+    public final ListPath<dailymissionproject.demo.domain.notify.repository.Notification, dailymissionproject.demo.domain.notify.repository.QNotification> notifications = this.<dailymissionproject.demo.domain.notify.repository.Notification, dailymissionproject.demo.domain.notify.repository.QNotification>createList("notifications", dailymissionproject.demo.domain.notify.repository.Notification.class, dailymissionproject.demo.domain.notify.repository.QNotification.class, PathInits.DIRECT2);
+
     public final ListPath<dailymissionproject.demo.domain.participant.repository.Participant, dailymissionproject.demo.domain.participant.repository.QParticipant> participants = this.<dailymissionproject.demo.domain.participant.repository.Participant, dailymissionproject.demo.domain.participant.repository.QParticipant>createList("participants", dailymissionproject.demo.domain.participant.repository.Participant.class, dailymissionproject.demo.domain.participant.repository.QParticipant.class, PathInits.DIRECT2);
 
     public final ListPath<dailymissionproject.demo.domain.post.repository.Post, dailymissionproject.demo.domain.post.repository.QPost> posts = this.<dailymissionproject.demo.domain.post.repository.Post, dailymissionproject.demo.domain.post.repository.QPost>createList("posts", dailymissionproject.demo.domain.post.repository.Post.class, dailymissionproject.demo.domain.post.repository.QPost.class, PathInits.DIRECT2);

--- a/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaConsumerConfig.java
+++ b/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaConsumerConfig.java
@@ -21,7 +21,7 @@ public class KafkaConsumerConfig {
     @Bean
     public ConsumerFactory<String, NotifyDto> consumerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "ec2-3-36-88-174.ap-northeast-2.compute.amazonaws.com:9092");
         config.put(ConsumerConfig.GROUP_ID_CONFIG, "group_1");
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaConsumerConfig.java
+++ b/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaConsumerConfig.java
@@ -1,0 +1,40 @@
+package dailymissionproject.demo.common.config.messaging.config;
+
+import dailymissionproject.demo.domain.notify.dto.NotifyDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, NotifyDto> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "group_1");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        JsonDeserializer<NotifyDto> deserializer = new JsonDeserializer<>(NotifyDto.class);
+        deserializer.addTrustedPackages("demo.common.config.messaging.config");
+
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, NotifyDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, NotifyDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaProducerConfig.java
+++ b/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaProducerConfig.java
@@ -1,0 +1,32 @@
+package dailymissionproject.demo.common.config.messaging.config;
+
+import dailymissionproject.demo.domain.notify.dto.NotifyDto;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, NotifyDto> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, NotifyDto> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaProducerConfig.java
+++ b/src/main/java/dailymissionproject/demo/common/config/messaging/config/KafkaProducerConfig.java
@@ -19,7 +19,7 @@ public class KafkaProducerConfig {
     @Bean
     public ProducerFactory<String, NotifyDto> producerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "ec2-3-36-88-174.ap-northeast-2.compute.amazonaws.com:9092");
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return new DefaultKafkaProducerFactory<>(config);

--- a/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
@@ -1,0 +1,39 @@
+package dailymissionproject.demo.domain.notify.controller;
+
+
+import dailymissionproject.demo.common.repository.CurrentUser;
+import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
+import dailymissionproject.demo.domain.notify.service.NotifyService;
+import dailymissionproject.demo.domain.user.exception.UserException;
+import dailymissionproject.demo.domain.user.exception.UserExceptionCode;
+import dailymissionproject.demo.domain.user.repository.User;
+import dailymissionproject.demo.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notify")
+public class NotifyController {
+
+    private final NotifyService notifyService;
+    private final UserRepository userRepository;
+
+    @GetMapping(value = "subscribe/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@CurrentUser CustomOAuth2User user) {
+        User findUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+        return notifyService.subscribe(findUser.getId());
+    }
+
+    @PostMapping("/send-data")
+    public void sendData(@CurrentUser CustomOAuth2User user) {
+        notifyService.notify(user.getId(), "data");
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
@@ -10,7 +10,9 @@ import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -23,11 +25,8 @@ public class NotifyController {
     private final NotifyService notifyService;
     private final UserRepository userRepository;
 
-    @GetMapping(value = "subscribe/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@CurrentUser CustomOAuth2User user) {
-        User findUser = userRepository.findById(user.getId())
-                .orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
-
-        return notifyService.subscribe(findUser.getId());
+        return notifyService.subscribe(user.getId());
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
@@ -11,14 +11,13 @@ import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/notify")
+@RequestMapping("/api/v1/notify")
 public class NotifyController {
 
     private final NotifyService notifyService;
@@ -30,10 +29,5 @@ public class NotifyController {
                 .orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
         return notifyService.subscribe(findUser.getId());
-    }
-
-    @PostMapping("/send-data")
-    public void sendData(@CurrentUser CustomOAuth2User user) {
-        notifyService.notify(user.getId(), "data");
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/controller/NotifyController.java
@@ -3,16 +3,11 @@ package dailymissionproject.demo.domain.notify.controller;
 
 import dailymissionproject.demo.common.repository.CurrentUser;
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
-import dailymissionproject.demo.domain.notify.service.NotifyService;
-import dailymissionproject.demo.domain.user.exception.UserException;
-import dailymissionproject.demo.domain.user.exception.UserExceptionCode;
-import dailymissionproject.demo.domain.user.repository.User;
+import dailymissionproject.demo.domain.notify.service.EmitterService;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -22,11 +17,10 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/notify")
 public class NotifyController {
 
-    private final NotifyService notifyService;
-    private final UserRepository userRepository;
+    private final EmitterService emitterService;
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@CurrentUser CustomOAuth2User user) {
-        return notifyService.subscribe(user.getId());
+        return emitterService.subscribe(user.getId());
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/notify/dto/NotifyDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/dto/NotifyDto.java
@@ -1,0 +1,23 @@
+package dailymissionproject.demo.domain.notify.dto;
+
+import dailymissionproject.demo.domain.notify.repository.Notification;
+import dailymissionproject.demo.domain.notify.repository.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class NotifyDto {
+
+    private final Long id;
+    private final String content;
+    private final NotificationType type;
+
+    @Builder
+    public NotifyDto(Long id, String content, NotificationType type) {
+        this.id = id;
+        this.content = content;
+        this.type = type;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/repository/EmitterRepository.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/repository/EmitterRepository.java
@@ -1,0 +1,4 @@
+package dailymissionproject.demo.domain.notify.repository;
+
+public interface EmitterRepository {
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,28 @@
+package dailymissionproject.demo.domain.notify.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+@RequiredArgsConstructor
+public class EmitterRepositoryImpl implements EmitterRepository {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(Long id, SseEmitter emitter) {
+        emitters.put(id, emitter);
+    }
+
+    public void delete(Long id) {
+        emitters.remove(id);
+    }
+
+    public SseEmitter get(Long id) {
+        return emitters.get(id);
+    }
+
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/repository/Notification.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/repository/Notification.java
@@ -1,0 +1,42 @@
+package dailymissionproject.demo.domain.notify.repository;
+
+import dailymissionproject.demo.common.repository.BaseTimeEntity;
+import dailymissionproject.demo.domain.user.repository.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Notification extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JoinColumn(name = "user_id")
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    private String content;
+
+    private boolean checked;
+
+    private boolean deleted;
+
+    @Builder
+    public Notification(Long id, User receiver, NotificationType notificationType, String content, boolean checked, boolean deleted) {
+        this.id = id;
+        this.receiver = receiver;
+        this.notificationType = notificationType;
+        this.content = content;
+        this.checked = checked;
+        this.deleted = deleted;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/repository/Notification.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/repository/Notification.java
@@ -16,7 +16,7 @@ public class Notification extends BaseTimeEntity {
     @Column(name = "notification_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private User receiver;
 
@@ -31,12 +31,20 @@ public class Notification extends BaseTimeEntity {
     private boolean deleted;
 
     @Builder
-    public Notification(Long id, User receiver, NotificationType notificationType, String content, boolean checked, boolean deleted) {
-        this.id = id;
+    public Notification(User receiver, NotificationType notificationType, String content) {
         this.receiver = receiver;
         this.notificationType = notificationType;
         this.content = content;
-        this.checked = checked;
-        this.deleted = deleted;
+
+        this.checked = false;
+        this.deleted = false;
+    }
+
+    public void isRead(){
+        checked = true;
+    }
+
+    public void delete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/dailymissionproject/demo/domain/notify/repository/NotificationType.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/repository/NotificationType.java
@@ -1,0 +1,5 @@
+package dailymissionproject.demo.domain.notify.repository;
+
+public enum NotificationType {
+    PARTICIPATE, POST, LIKE
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/repository/NotifyRepository.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/repository/NotifyRepository.java
@@ -1,0 +1,6 @@
+package dailymissionproject.demo.domain.notify.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotifyRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/service/NotificationService.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/service/NotificationService.java
@@ -1,0 +1,26 @@
+package dailymissionproject.demo.domain.notify.service;
+
+import dailymissionproject.demo.domain.notify.dto.NotifyDto;
+import dailymissionproject.demo.domain.notify.repository.NotificationType;
+import dailymissionproject.demo.domain.user.repository.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationService {
+    private final KafkaTemplate<String, NotifyDto> kafkaTemplate;
+
+    public void createNotification(User receiver, NotificationType notificationType, Object event){
+        NotifyDto notifyDto = NotifyDto.builder()
+                .id(receiver.getId())
+                .content(String.valueOf(event))
+                .type(notificationType)
+                .build();
+
+        kafkaTemplate.send("notify", notifyDto);
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
@@ -59,6 +59,8 @@ public class NotifyService {
 
         if (Objects.isNull(emitter)) {
             log.warn("연결중이지 않은 userId={}", receiver.getId());
+            notifyRepository.save(notification);
+            return;
         }
 
         NotifyDto response = NotifyDto.builder()

--- a/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
@@ -1,6 +1,11 @@
 package dailymissionproject.demo.domain.notify.service;
 
-import dailymissionproject.demo.domain.notify.repository.EmitterRepository;
+import dailymissionproject.demo.domain.notify.repository.EmitterRepositoryImpl;
+import dailymissionproject.demo.domain.notify.repository.Notification;
+import dailymissionproject.demo.domain.notify.repository.NotificationType;
+import dailymissionproject.demo.domain.notify.repository.NotifyRepository;
+import dailymissionproject.demo.domain.user.repository.User;
+import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -13,7 +18,9 @@ import java.util.Objects;
 public class NotifyService {
 
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
-    private final EmitterRepository emitterRepository;
+    private final EmitterRepositoryImpl emitterRepository;
+    private final NotifyRepository notifyRepository;
+    private final UserRepository userRepository;
 
 
     //Emitter 생성
@@ -24,8 +31,15 @@ public class NotifyService {
         return emitter;
     }
 
-    public void notify(Long userId, Object event){
-        sendToClient(userId, event);
+    public void notify(User receiver, NotificationType notificationType, Object event){
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .content(String.valueOf(event))
+                .notificationType(notificationType)
+                .build();
+
+        sendToClient(receiver.getId(), event);
+        notifyRepository.save(notification);
     }
 
     private void sendToClient(Long userId, Object data) {

--- a/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
@@ -1,20 +1,29 @@
 package dailymissionproject.demo.domain.notify.service;
 
+import dailymissionproject.demo.domain.notify.dto.NotifyDto;
 import dailymissionproject.demo.domain.notify.repository.EmitterRepositoryImpl;
 import dailymissionproject.demo.domain.notify.repository.Notification;
 import dailymissionproject.demo.domain.notify.repository.NotificationType;
 import dailymissionproject.demo.domain.notify.repository.NotifyRepository;
+import dailymissionproject.demo.domain.user.exception.UserException;
+import dailymissionproject.demo.domain.user.exception.UserExceptionCode;
 import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.weaver.ast.Not;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotifyService {
 
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
@@ -25,35 +34,52 @@ public class NotifyService {
 
     //Emitter 생성
     public SseEmitter subscribe(Long userId){
+        User findUser = userRepository.findById(userId).orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
         SseEmitter emitter = create(userId);
 
-        sendToClient(userId, "Event stream is created. [userId : " +  userId + "]");
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(String.valueOf(userId))
+                    .data("Event created. [userId = " + userId + "]"));
+        } catch (IOException e) {
+            throw new RuntimeException("전송에 실패했습니다.");
+        }
+
         return emitter;
     }
 
-    public void notify(User receiver, NotificationType notificationType, Object event){
+    public void send(User receiver, NotificationType notificationType, Object event){
         Notification notification = Notification.builder()
                 .receiver(receiver)
                 .content(String.valueOf(event))
                 .notificationType(notificationType)
                 .build();
 
-        sendToClient(receiver.getId(), event);
+        SseEmitter emitter = emitterRepository.get(receiver.getId());
+
+        if (Objects.isNull(emitter)) {
+            log.warn("연결중이지 않은 userId={}", receiver.getId());
+        }
+
+        NotifyDto response = NotifyDto.builder()
+                .id(receiver.getId())
+                .content(String.valueOf(event))
+                .type(notificationType)
+                .build();
+
+        sendNotification(emitter, response);
         notifyRepository.save(notification);
     }
 
-    private void sendToClient(Long userId, Object data) {
-        SseEmitter emitter = emitterRepository.get(userId);
-
-        if(!Objects.isNull(emitter)){
-            try {
-                emitter.send(data);
-            } catch (IOException e) {
-                throw new RuntimeException("연결 오류!");
-            }
+    private void sendNotification(SseEmitter emitter, NotifyDto response) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(String.valueOf(response.getId()))
+                    .data(response));
+        } catch (IOException e) {
+            throw new RuntimeException("전송에 실패했습니다.");
         }
     }
-
 
     private SseEmitter create(Long userId){
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);

--- a/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/service/NotifyService.java
@@ -1,0 +1,53 @@
+package dailymissionproject.demo.domain.notify.service;
+
+import dailymissionproject.demo.domain.notify.repository.EmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class NotifyService {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    private final EmitterRepository emitterRepository;
+
+
+    //Emitter 생성
+    public SseEmitter subscribe(Long userId){
+        SseEmitter emitter = create(userId);
+
+        sendToClient(userId, "Event stream is created. [userId : " +  userId + "]");
+        return emitter;
+    }
+
+    public void notify(Long userId, Object event){
+        sendToClient(userId, event);
+    }
+
+    private void sendToClient(Long userId, Object data) {
+        SseEmitter emitter = emitterRepository.get(userId);
+
+        if(!Objects.isNull(emitter)){
+            try {
+                emitter.send(data);
+            } catch (IOException e) {
+                throw new RuntimeException("연결 오류!");
+            }
+        }
+    }
+
+
+    private SseEmitter create(Long userId){
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(userId, emitter);
+
+        emitter.onCompletion(() -> emitterRepository.delete(userId));
+        emitter.onTimeout(() -> emitterRepository.delete(userId));
+
+        return emitter;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
@@ -94,6 +94,7 @@ public class ParticipantService {
 
     /**
      * 신규 미션 참여자가 발생할 경우 참여중인 유저들에게 푸시 알람을 보낸다.
+     * 미션에 참여한 당사자를 제외하고 알림 발생
      * @param newUser
      * @param mission
      */
@@ -104,7 +105,7 @@ public class ParticipantService {
                 continue;
             }
 
-            notifyService.notify(participant.getUser(), NotificationType.PARTICIPATE, "신규 참여자 " + newUser.getNickname() + "님이 참여했습니다.");
+            notifyService.send(participant.getUser(), NotificationType.PARTICIPATE, "신규 참여자 " + newUser.getNickname() + "님이 참여했습니다.");
         }
     }
 

--- a/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
@@ -5,7 +5,8 @@ import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.mission.repository.MissionRepository;
 import dailymissionproject.demo.domain.notify.repository.NotificationType;
-import dailymissionproject.demo.domain.notify.service.NotifyService;
+import dailymissionproject.demo.domain.notify.service.EmitterService;
+import dailymissionproject.demo.domain.notify.service.NotificationService;
 import dailymissionproject.demo.domain.participant.dto.request.ParticipantSaveRequestDto;
 import dailymissionproject.demo.domain.participant.exception.ParticipantException;
 import dailymissionproject.demo.domain.participant.repository.Participant;
@@ -37,7 +38,7 @@ public class ParticipantService {
     private final UserRepository userRepository;
     private final MissionRepository missionRepository;
     private final PostService postService;
-    private final NotifyService notifyService;
+    private final NotificationService notificationService;
 
     /**
      *
@@ -105,7 +106,7 @@ public class ParticipantService {
                 continue;
             }
 
-            notifyService.send(participant.getUser(), NotificationType.PARTICIPATE, "신규 참여자 " + newUser.getNickname() + "님이 참여했습니다.");
+            notificationService.createNotification(participant.getUser(), NotificationType.PARTICIPATE, "신규 참여자 " + newUser.getNickname() + "님이 참여했습니다.");
         }
     }
 

--- a/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
+++ b/src/main/java/dailymissionproject/demo/domain/participant/service/ParticipantService.java
@@ -4,6 +4,8 @@ import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.mission.repository.MissionRepository;
+import dailymissionproject.demo.domain.notify.repository.NotificationType;
+import dailymissionproject.demo.domain.notify.service.NotifyService;
 import dailymissionproject.demo.domain.participant.dto.request.ParticipantSaveRequestDto;
 import dailymissionproject.demo.domain.participant.exception.ParticipantException;
 import dailymissionproject.demo.domain.participant.repository.Participant;
@@ -35,7 +37,7 @@ public class ParticipantService {
     private final UserRepository userRepository;
     private final MissionRepository missionRepository;
     private final PostService postService;
-
+    private final NotifyService notifyService;
 
     /**
      *
@@ -85,7 +87,25 @@ public class ParticipantService {
 
         Participant participant = requestDto.toEntity(findUser, findMission);
         participantRepository.save(participant);
+
+        sendParticipationNotify(findUser, findMission);
         return true;
+    }
+
+    /**
+     * 신규 미션 참여자가 발생할 경우 참여중인 유저들에게 푸시 알람을 보낸다.
+     * @param newUser
+     * @param mission
+     */
+    private void sendParticipationNotify(User newUser, Mission mission){
+
+        for(Participant participant : mission.getParticipants()){
+            if((participant.getUser().getId().equals(newUser.getId()))){
+                continue;
+            }
+
+            notifyService.notify(participant.getUser(), NotificationType.PARTICIPATE, "신규 참여자 " + newUser.getNickname() + "님이 참여했습니다.");
+        }
     }
 
     @Transactional

--- a/src/main/java/dailymissionproject/demo/domain/post/service/PostService.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/service/PostService.java
@@ -2,14 +2,14 @@ package dailymissionproject.demo.domain.post.service;
 
 
 import dailymissionproject.demo.domain.auth.dto.CustomOAuth2User;
-import dailymissionproject.demo.domain.image.service.ImageService;
 import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.mission.repository.MissionRepository;
 import dailymissionproject.demo.domain.missionRule.dto.DateDto;
 import dailymissionproject.demo.domain.notify.repository.NotificationType;
-import dailymissionproject.demo.domain.notify.service.NotifyService;
+import dailymissionproject.demo.domain.notify.service.EmitterService;
+import dailymissionproject.demo.domain.notify.service.NotificationService;
 import dailymissionproject.demo.domain.participant.repository.Participant;
 import dailymissionproject.demo.domain.post.dto.PostScheduleResponseDto;
 import dailymissionproject.demo.domain.post.dto.PostSubmitDto;
@@ -51,7 +51,7 @@ public class PostService {
     private final MissionRepository missionRepository;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
-    private final NotifyService notifyService;
+    private final NotificationService notificationService;
     /**
      * 포스트를 작성할 때 사용하는 메서드
      * @param user
@@ -92,7 +92,7 @@ public class PostService {
                 continue;
             }
 
-            notifyService.send(participant.getUser(), NotificationType.POST, poster.getNickname() + "님이 포스트를 제출했습니다!");
+            notificationService.createNotification(participant.getUser(), NotificationType.POST, poster.getNickname() + "님이 포스트를 제출했습니다!");
         }
     }
 

--- a/src/main/java/dailymissionproject/demo/domain/user/repository/User.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/repository/User.java
@@ -33,7 +33,7 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user")
     List<Participant> participants = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "receiver")
     List<Notification> notifications = new ArrayList<>();
 
     private String name;

--- a/src/main/java/dailymissionproject/demo/domain/user/repository/User.java
+++ b/src/main/java/dailymissionproject/demo/domain/user/repository/User.java
@@ -2,6 +2,7 @@ package dailymissionproject.demo.domain.user.repository;
 
 import dailymissionproject.demo.common.repository.BaseTimeEntity;
 import dailymissionproject.demo.domain.mission.repository.Mission;
+import dailymissionproject.demo.domain.notify.repository.Notification;
 import dailymissionproject.demo.domain.participant.repository.Participant;
 import dailymissionproject.demo.domain.post.repository.Post;
 import jakarta.persistence.*;
@@ -29,8 +30,11 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user")
     List<Post> posts = new ArrayList<>();
 
-   @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user")
     List<Participant> participants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    List<Notification> notifications = new ArrayList<>();
 
     private String name;
     private String email;

--- a/src/test/java/dailymissionproject/demo/global/config/IntegrationTestSupport.java
+++ b/src/test/java/dailymissionproject/demo/global/config/IntegrationTestSupport.java
@@ -44,7 +44,7 @@ import org.testcontainers.utility.DockerImageName;
         "spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token",
         "security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me",
         "spring.security.oauth2.client.provider.naver.user-name-attribute=response",
-        "spring.data.redis.host=ec2-43-201-86-45.ap-northeast-2.compute.amazonaws.com",
+        "spring.data.redis.host=ec2-3-36-88-174.ap-northeast-2.compute.amazonaws.com",
         "spring.data.redis.port=6379"
 })
 public abstract class IntegrationTestSupport {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #94            

## 📝작업 내용

> 실시간 이벤트 스트리밍 구현 SSE & Kafka
- kafka 의존성 추가
- 구독 api 작성
- 알람 저장 Notification 클래스 작성
- kafka consumer, producer config 작성
- 미션 참여, 포스트 작성 시 message produce 로직 작성
- sse 데이터 전송 kafkaListener 구현 
- redis 이관 및 kafka 브로커 서버 세팅