### PR TITLE
Pr/101/redis pubsub 전환

### DIFF
--- a/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/fixture/PostObjectFixture.java
@@ -47,6 +47,7 @@ public class PostObjectFixture {
      * @return Mission
      */
     public static Mission getMissionFixture(){
+        User user = new User(1L, "윤성철", "proattacker@naver.com", "성철");
         Mission mission =  Mission.builder()
                 .title("TITLE")
                 .content("CONTENT")
@@ -55,13 +56,13 @@ public class PostObjectFixture {
                 .credential("CREDENTIAL")
                 .startDate(LocalDate.now())
                 .endDate(LocalDate.now().plusDays(10))
-                .user(getUserFixture())
+                .user(user)
                 .missionRule(getMissionRuleFixture())
                 .build();
 
         Participant participant_1 = Participant.builder()
                 .mission(mission)
-                .user(getUserFixture())
+                .user(user)
                 .build();
 
         mission.setParticipants(List.of(participant_1));

--- a/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
@@ -6,6 +6,7 @@ import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.exception.MissionException;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.mission.repository.MissionRepository;
+import dailymissionproject.demo.domain.notify.service.NotificationService;
 import dailymissionproject.demo.domain.post.dto.request.PostSaveRequestDto;
 import dailymissionproject.demo.domain.post.dto.request.PostUpdateRequestDto;
 import dailymissionproject.demo.domain.post.dto.response.*;
@@ -55,6 +56,8 @@ class PostServiceTest {
     private MissionRepository missionRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private NotificationService notificationService;
 
     private final Mission mission = PostObjectFixture.getMissionFixture();
     private final User user = PostObjectFixture.getUserFixture();
@@ -79,8 +82,6 @@ class PostServiceTest {
     @Nested
     @DisplayName("포스트 생성 서비스 레이어 테스트")
     class PostSaveServiceTest {
-        final String fileName = "userModifyImage";
-        final String contentType = "image/jpeg";
 
         @Test
         @DisplayName("포스트를 생성할 수 있다.")
@@ -88,7 +89,6 @@ class PostServiceTest {
             when(missionRepository.findByIdAndDeletedIsFalse(anyLong())).thenReturn(Optional.of(mission));
             when(userRepository.findById(any())).thenReturn(Optional.of(user));
 
-            //boolean result = postService.isParticipating(user, mission);
             PostSaveResponseDto saveResponse = postService.save(oAuth2User, saveRequest);
 
 

--- a/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
@@ -86,8 +86,9 @@ class PostServiceTest {
         @Test
         @DisplayName("포스트를 생성할 수 있다.")
         void post_save_success() throws IOException {
+            User poster = new User(1L, "윤성철", "proattacker@naver.com", "성철");
             when(missionRepository.findByIdAndDeletedIsFalse(anyLong())).thenReturn(Optional.of(mission));
-            when(userRepository.findById(any())).thenReturn(Optional.of(user));
+            when(userRepository.findById(any())).thenReturn(Optional.of(poster));
 
             PostSaveResponseDto saveResponse = postService.save(oAuth2User, saveRequest);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #104               

## 📝작업 내용

> 실시간 푸시 알림 : kafka -> Redis pub/sub으로 전환
- kafka 의존성 제거 및 관련 config 파일 제거
- kafka, zookeeper 컨테이너 중지 및 이미지 삭제
- Redis pub/sub 의존성 작성
- 관련 로직 수정
- fixture 객체 수정