### PR TITLE
Pr/114/post like field추가

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/notify/service/EmitterService.java
+++ b/src/main/java/dailymissionproject/demo/domain/notify/service/EmitterService.java
@@ -2,8 +2,6 @@ package dailymissionproject.demo.domain.notify.service;
 
 import dailymissionproject.demo.domain.notify.dto.NotifyDto;
 import dailymissionproject.demo.domain.notify.repository.emitter.EmitterRepositoryImpl;
-import dailymissionproject.demo.domain.notify.repository.Notification;
-import dailymissionproject.demo.domain.notify.repository.NotificationRepository;
 import dailymissionproject.demo.domain.user.exception.UserException;
 import dailymissionproject.demo.domain.user.exception.UserExceptionCode;
 import dailymissionproject.demo.domain.user.repository.User;
@@ -11,11 +9,9 @@ import dailymissionproject.demo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +22,7 @@ public class EmitterService {
     private final UserRepository userRepository;
 
     private final static String NOTIFY_NAME = "notify";
-    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    private static final Long DEFAULT_TIMEOUT = 15L * 1000 * 60;
 
     public void subscribe(SseEmitter emitter, Long userId){
         try {

--- a/src/main/java/dailymissionproject/demo/domain/post/controller/PostController.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/controller/PostController.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
@@ -109,8 +108,8 @@ public class PostController {
             @ApiResponse(responseCode = "404", description = "포스트 조회에 실패하였습니다."),
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
     })
-    public ResponseEntity<GlobalResponse> findByMission(@PathVariable("id") Long id, Pageable pageable){
-        PageResponseDto response = postService.findAllByMission(id, pageable);
+    public ResponseEntity<GlobalResponse> findByMission(@CurrentUser CustomOAuth2User user, @PathVariable("id") Long id, Pageable pageable){
+        PageResponseDto response = postService.findAllByMission(user, id, pageable);
 
         return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
     }

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostMissionListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostMissionListResponseDto.java
@@ -37,7 +37,7 @@ public class PostMissionListResponseDto {
     @Schema(description = "포스트 좋아요")
     private final Long likeCount;
     @Schema(description = "해당 유저가 좋아요를 눌렀는지 여부")
-    private final boolean isLiked;
+    private final boolean liked;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
@@ -51,7 +51,7 @@ public class PostMissionListResponseDto {
 
     @Builder
     public PostMissionListResponseDto(Long id, Long missionId, String nickname, String userImageUrl, String title
-            , String content, String imageUrl, Long likeCount, boolean isLiked
+            , String content, String imageUrl, Long likeCount, boolean liked
             , LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.missionId = missionId;
@@ -61,7 +61,7 @@ public class PostMissionListResponseDto {
         this.content = content;
         this.imageUrl = imageUrl;
         this.likeCount = likeCount;
-        this.isLiked = isLiked;
+        this.liked = liked;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
     }

--- a/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostMissionListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/dto/response/PostMissionListResponseDto.java
@@ -36,6 +36,8 @@ public class PostMissionListResponseDto {
     private final String imageUrl;
     @Schema(description = "포스트 좋아요")
     private final Long likeCount;
+    @Schema(description = "해당 유저가 좋아요를 눌렀는지 여부")
+    private final boolean isLiked;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
@@ -49,7 +51,8 @@ public class PostMissionListResponseDto {
 
     @Builder
     public PostMissionListResponseDto(Long id, Long missionId, String nickname, String userImageUrl, String title
-            , String content, String imageUrl, Long likeCount, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+            , String content, String imageUrl, Long likeCount, boolean isLiked
+            , LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.missionId = missionId;
         this.nickname = nickname;
@@ -58,6 +61,7 @@ public class PostMissionListResponseDto {
         this.content = content;
         this.imageUrl = imageUrl;
         this.likeCount = likeCount;
+        this.isLiked = isLiked;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
     }

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustom.java
@@ -20,7 +20,7 @@ public interface PostRepositoryCustom {
 
     Slice<PostUserListResponseDto> findAllByUser(Pageable pageable, User user);
 
-    Slice<PostMissionListResponseDto> findAllByMission(Pageable pageable, Mission mission);
+    Slice<PostMissionListResponseDto> findAllByMission(Pageable pageable, Mission mission, User user);
 
     //List<Post> findAllByUser(User user);
 

--- a/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/repository/PostRepositoryCustomImpl.java
@@ -1,7 +1,10 @@
 package dailymissionproject.demo.domain.post.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import dailymissionproject.demo.domain.like.repository.QLikes;
 import dailymissionproject.demo.domain.mission.repository.Mission;
 import dailymissionproject.demo.domain.post.dto.PostSubmitDto;
 import dailymissionproject.demo.domain.post.dto.response.PostMissionListResponseDto;
@@ -97,8 +100,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
      * @return
      */
     @Override
-    public Slice<PostMissionListResponseDto> findAllByMission(Pageable pageable, Mission mission) {
-        List<PostMissionListResponseDto> postList = fetchAllByMission(pageable, mission);
+    public Slice<PostMissionListResponseDto> findAllByMission(Pageable pageable, Mission mission, User user) {
+        List<PostMissionListResponseDto> postList = fetchAllByMission(pageable, mission, user);
         boolean hasNext = hasNextPage(postList, pageable);
 
         return new SliceImpl<>(postList, pageable, hasNext);
@@ -110,7 +113,9 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
      * @param mission
      * @return
      */
-    List<PostMissionListResponseDto> fetchAllByMission(Pageable pageable, Mission mission) {
+    List<PostMissionListResponseDto> fetchAllByMission(Pageable pageable, Mission mission, User user) {
+        QLikes like = QLikes.likes;
+
         return queryFactory
                 .select(Projections.fields(PostMissionListResponseDto.class,
                         post.id.as("id"),
@@ -121,6 +126,12 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                         post.content,
                         post.imageUrl,
                         post.likeCount.as("likeCount"),
+                        JPAExpressions
+                                .selectOne()
+                                .from(like)
+                                .where(like.user.eq(user)
+                                        .and(like.post.eq(post)))
+                                .exists().as("liked"),
                         post.createdDate,
                         post.modifiedDate))
                 .from(post)
@@ -130,6 +141,17 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
+    }
+
+    private BooleanExpression isLiked(User user, Post post){
+        QLikes like = QLikes.likes;
+
+        return JPAExpressions
+                .selectOne()
+                .from(like)
+                .where(like.user.eq(user)
+                        .and(like.post.eq(post)))
+                .exists();
     }
 
     /**

--- a/src/main/java/dailymissionproject/demo/domain/post/service/PostService.java
+++ b/src/main/java/dailymissionproject/demo/domain/post/service/PostService.java
@@ -21,10 +21,7 @@ import dailymissionproject.demo.domain.post.repository.PostRepository;
 import dailymissionproject.demo.domain.user.exception.UserException;
 import dailymissionproject.demo.domain.user.repository.User;
 import dailymissionproject.demo.domain.user.repository.UserRepository;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -133,24 +130,13 @@ public class PostService {
      * @return
      */
     @Transactional(readOnly = true)
-    @CircuitBreaker(name = "redis-circuit-breaker", fallbackMethod = "findAllByMissionFallBack")
-    public PageResponseDto findAllByMission(Long id, Pageable pageable){
-
+    public PageResponseDto findAllByMission(CustomOAuth2User user, Long id, Pageable pageable){
+        User findUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
         Mission mission = missionRepository.findById(id)
                 .orElseThrow(() -> new MissionException(MISSION_NOT_FOUND));
 
-        Slice<PostMissionListResponseDto> missionPostList = postRepository.findAllByMission(pageable, mission);
-
-        PageResponseDto pageResponseDto = new PageResponseDto<>(missionPostList.getContent(), missionPostList.hasNext());
-
-        return pageResponseDto;
-    }
-
-    public PageResponseDto findAllByMissionFallBack(Long id, Pageable pageable, Throwable e){
-        Mission mission = missionRepository.findById(id)
-                .orElseThrow(() -> new MissionException(MISSION_NOT_FOUND));
-
-        Slice<PostMissionListResponseDto> missionPostList = postRepository.findAllByMission(pageable, mission);
+        Slice<PostMissionListResponseDto> missionPostList = postRepository.findAllByMission(pageable, mission, findUser);
 
         PageResponseDto pageResponseDto = new PageResponseDto<>(missionPostList.getContent(), missionPostList.hasNext());
 

--- a/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/controller/PostControllerTest.java
@@ -24,13 +24,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
@@ -198,7 +195,7 @@ class PostControllerTest {
             Slice<PostMissionListResponseDto> sliceList = new SliceImpl<>(missionPostList, pageable, false);
             PageResponseDto response = new PageResponseDto<>(sliceList, false);
 
-            when(postService.findAllByMission(any(), any())).thenReturn(response);
+            when(postService.findAllByMission(any(), any(), any())).thenReturn(response);
 
             ResultActions resultActions = mockMvc.perform(get("/api/v1/post/mission/{id}", missionId)
                     .with(csrf()))
@@ -213,14 +210,14 @@ class PostControllerTest {
         @Test
         @DisplayName("미션 정보가 없을경우 예외를 반환한다.")
         void post_read_mission_list_fail_when_mission_not_exits() throws Exception {
-            when(postService.findAllByMission(any(), any())).thenThrow(new MissionException(MissionExceptionCode.MISSION_NOT_FOUND));
+            when(postService.findAllByMission(any(), any(), any())).thenThrow(new MissionException(MissionExceptionCode.MISSION_NOT_FOUND));
 
             mockMvc.perform(get("/api/v1/post/mission/{id}", missionId)
                     .with(csrf()))
                     .andExpect(status().isBadRequest());
 
             verify(postService, description("findAllByMission 메서드가 정상 호출됨"))
-                    .findAllByMission(any(), any());
+                    .findAllByMission(any(), any(), any());
         }
     }
 

--- a/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/post/service/PostServiceTest.java
@@ -191,13 +191,15 @@ class PostServiceTest {
         @DisplayName("미션별 포스트 리스트를 조회할 수 있다.")
         void post_mission_list_read_success() throws Exception {
             //given
+            User user = new User(1L, "윤성철", "proattacker@naver.com", "성철");
             Pageable pageable = PageRequest.of(0, 3);
 
+            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
             when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
-            when(postRepository.findAllByMission(pageable, mission))
+            when(postRepository.findAllByMission(pageable, mission, user))
                     .thenReturn(new SliceImpl<>(missionListResponse, pageable, false));
 
-            PageResponseDto pageResponseDto = postService.findAllByMission(missionId, pageable);
+            PageResponseDto pageResponseDto = postService.findAllByMission(oAuth2User, missionId, pageable);
             List<PostMissionListResponseDto> responseList = (List<PostMissionListResponseDto>) pageResponseDto.content();
 
             assertEquals(responseList.get(0).getTitle(), missionListResponse.get(0).getTitle());
@@ -210,9 +212,10 @@ class PostServiceTest {
         void post_mission_list_read_fail_when_mission_is_not_exists() throws Exception {
             Pageable pageable = PageRequest.of(0, 3);
 
+            when(userRepository.findById(oAuth2User.getId())).thenReturn(Optional.of(user));
             when(missionRepository.findById(any())).thenThrow(new MissionException(MISSION_NOT_FOUND));
 
-            MissionException missionException = assertThrows(MissionException.class, () -> postService.findAllByMission(missionId, pageable));
+            MissionException missionException = assertThrows(MissionException.class, () -> postService.findAllByMission(oAuth2User, missionId, pageable));
             assertEquals(MISSION_NOT_FOUND, missionException.getExceptionCode());
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

>      

## 📝작업 내용

> 미션의 Post 리스트 조회 시, 각 post에 대해 유저가 좋아요를 눌렀는지 확인을 위해 필드 추가
- 응답DTO의 boolean 타입의 liked 필드 추가
- 관련 swagger 반영
- controller와 service 계층에서 쿼리 조회를 위해 user 파라미터를 넘기도록 로직 수정
- post 조회 관련 단위테스트 수정