### PR TITLE
Pr/종료된미션 조회기능 추가

### DIFF
--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -185,7 +185,7 @@ public class MissionController {
      * @return PageResponseDto
      */
     @GetMapping("/end")
-    @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
+    @Operation(summary = "종료 미션 확인", description = "종료된 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공!"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST !!"),

--- a/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/controller/MissionController.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
@@ -176,6 +175,25 @@ public class MissionController {
     })
     public ResponseEntity<GlobalResponse> findAllList(Pageable pageable, @CurrentUser CustomOAuth2User user){
         PageResponseDto response = missionService.findAllList(pageable, user);
+
+        return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
+    }
+
+    /**
+     * 전체 미션 리스트 조회
+     * @param pageable
+     * @return PageResponseDto
+     */
+    @GetMapping("/end")
+    @Operation(summary = "모든 미션 확인", description = "모든 미션 목록을 확인하고 싶을 때 사용하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공!"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST !!"),
+            @ApiResponse(responseCode = "404", description = "권한을 확인해주세요."),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR !!")
+    })
+    public ResponseEntity<GlobalResponse> findEndList(Pageable pageable, @CurrentUser CustomOAuth2User user){
+        PageResponseDto response = missionService.findEndList(pageable, user);
 
         return ResponseEntity.ok(success(response.content(), MetaService.createMetaInfo().add("isNext", response.next())));
     }

--- a/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionEndedListResponseDto.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/dto/response/MissionEndedListResponseDto.java
@@ -1,0 +1,54 @@
+package dailymissionproject.demo.domain.mission.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "종료 미션 목록")
+public class MissionEndedListResponseDto {
+
+    @Schema(description = "미션 PK ID")
+    private Long id;
+    @Schema(description = "미션 제목")
+    private String title;
+    @Schema(description = "미션 내용")
+    private String content;
+    @Schema(description = "미션 썸네일")
+    private String imageUrl;
+    @Schema(description = "미션 방장 닉네임")
+    private String nickname;
+
+    @Schema(description = "미션 시작일자")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
+    private LocalDate startDate;
+
+    @Schema(description = "미션 종료일자")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
+    private LocalDate endDate;
+
+    @Builder
+    MissionEndedListResponseDto(Long id, String title, String content, String imageUrl, String nickname
+            , LocalDate startDate, LocalDate endDate) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.nickname = nickname;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustom.java
@@ -1,6 +1,7 @@
 package dailymissionproject.demo.domain.mission.repository;
 
 import dailymissionproject.demo.domain.mission.dto.response.MissionAllListResponseDto;
+import dailymissionproject.demo.domain.mission.dto.response.MissionEndedListResponseDto;
 import dailymissionproject.demo.domain.mission.dto.response.MissionHotListResponseDto;
 import dailymissionproject.demo.domain.mission.dto.response.MissionNewListResponseDto;
 import org.springframework.data.domain.Page;
@@ -11,44 +12,11 @@ import java.util.List;
 
 public interface MissionRepositoryCustom {
 
-    //== Pagination 적용 ==//
-    //Hot 미션 목록
     Slice<MissionHotListResponseDto> findAllByParticipantSize(Pageable pageable, Long userId);
-
-    //New 미션 목록
     Slice<MissionNewListResponseDto> findAllByCreatedInMonth(Pageable pageable, Long userId);
-
-    //All 미션 목록
     Slice<MissionAllListResponseDto> findAllByCreatedDate(Pageable pageable, Long userId);
+    Slice<MissionEndedListResponseDto> findAllByEnded(Pageable pageable, Long userId);
     List<Mission> findAllByCreatedDate();
 
     Page<Mission> findAllAndEndedIsFalse(Pageable pageable);
-    /*
-        @Override
-        public List<Mission> findAllByParticipantSize() {
-            return queryFactory
-                    .select(mission)
-                    .from(mission)
-                    .where(mission.deleted.isFalse().and(mission.ended.isFalse()))
-                    .orderBy(mission.participants.size().desc(), mission.createdTime.desc())
-                    .fetch();
-        }
-
-        @Override
-        public List<Mission> findAllByCreatedInMonth() {
-            return queryFactory
-                    .select(mission)
-                    .from(mission)
-                    .where(mission.deleted.isFalse(), mission.ended.isFalse())
-                    .orderBy(mission.createdTime.desc())
-                    .fetch();
-        }
-        */
-
-
-
-    //List<Mission> findAllByParticipantSize();
-    //List<Mission> findAllByCreatedInMonth();
-
-    //List<Mission> findAllByCreatedDate();
 }

--- a/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryCustomImpl.java
@@ -1,18 +1,13 @@
 package dailymissionproject.demo.domain.mission.repository;
 
-import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dailymissionproject.demo.domain.mission.dto.response.MissionAllListResponseDto;
+import dailymissionproject.demo.domain.mission.dto.response.MissionEndedListResponseDto;
 import dailymissionproject.demo.domain.mission.dto.response.MissionHotListResponseDto;
 import dailymissionproject.demo.domain.mission.dto.response.MissionNewListResponseDto;
-import dailymissionproject.demo.domain.participant.repository.QParticipant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
-import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
@@ -120,6 +115,33 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .fetch();
     }
 
+    @Override
+    public Slice<MissionEndedListResponseDto> findAllByEnded(Pageable pageable, Long userId) {
+        List<MissionEndedListResponseDto> missionList = fetchMissionByEnded(pageable, userId);
+        boolean hasNext = hasNextPage(missionList, pageable);
+
+        return new SliceImpl<>(missionList, pageable, hasNext);
+    }
+
+    public List<MissionEndedListResponseDto> fetchMissionByEnded(Pageable pageable, Long userId){
+
+        return queryFactory
+                .select(Projections.fields(MissionEndedListResponseDto.class,
+                        mission.id,
+                        mission.title,
+                        mission.content,
+                        mission.imageUrl,
+                        mission.user.nickname,
+                        mission.startDate,
+                        mission.endDate
+                ))
+                .from(mission)
+                .where(mission.ended.isTrue())
+                .orderBy(mission.endDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
     /**
      * Pageable 요청객체의 사이즈와 비교해서 크다면, true를 리턴한다.
      * @param missionList

--- a/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
@@ -249,6 +249,8 @@ public class MissionService {
         return pageResponseDto;
     }
 
+    @Transactional(readOnly = true)
+    @Cacheable(value = "missionLists", key = "'end-' + 'page-' + #pageable.getPageNumber() + 'size-' + #pageable.getPageSize()")
     public PageResponseDto findEndList(Pageable pageable, CustomOAuth2User user){
         Slice<MissionEndedListResponseDto> responses = missionRepository.findAllByEnded(pageable, user.getId());
 

--- a/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
+++ b/src/main/java/dailymissionproject/demo/domain/mission/service/MissionService.java
@@ -249,6 +249,14 @@ public class MissionService {
         return pageResponseDto;
     }
 
+    public PageResponseDto findEndList(Pageable pageable, CustomOAuth2User user){
+        Slice<MissionEndedListResponseDto> responses = missionRepository.findAllByEnded(pageable, user.getId());
+
+        PageResponseDto pageResponseDto = new PageResponseDto(responses.getContent(), responses.hasNext());
+
+        return pageResponseDto;
+    }
+
     /**
      * 현재 로그인한 유저가 참여 전적이 있는 미션 전체를 조회할 때 사용하는 API
      * 설명 : 전체 미션을 조회하고, 미션 참여자 리스트에 Request 유저가 있다면, List에 추가해 반환한다.

--- a/src/test/java/dailymissionproject/demo/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/controller/MissionControllerTest.java
@@ -22,13 +22,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -76,6 +73,7 @@ class MissionControllerTest {
     private final PageResponseDto hotMissionListResponse = MissionObjectFixture.getHotMissionListResponse();
     private final PageResponseDto newMissionListResponse = MissionObjectFixture.getNewMissionListResponse();
     private final PageResponseDto allMissionListResponse = MissionObjectFixture.getAllMissionListResponse();
+    private final PageResponseDto endMissionListResponse = MissionObjectFixture.getEndMissionListResponse();
 
 
     private final Pageable pageable = PageRequest.of(0,3 );
@@ -232,6 +230,40 @@ class MissionControllerTest {
             resultActions.andExpect(jsonPath("$.data[0].nickname").value(allMission_1.getNickname()));
             resultActions.andExpect(jsonPath("$.data[0].startDate").value(allMission_1.getStartDate().toString()));
             resultActions.andExpect(jsonPath("$.data[0].endDate").value(allMission_1.getEndDate().toString()));
+        }
+
+        @Test
+        @DisplayName("종료된 미션 리스트를 조회할 수 있다.")
+        void end_mission_read_list_success() throws Exception {
+            //given
+            MissionEndedListResponseDto endMission_1 = MissionEndedListResponseDto.builder()
+                    .id(1L)
+                    .title("종료미션")
+                    .content("종료된 미션입니다.")
+                    .imageUrl("END_THUMBNAIL1.jpg")
+                    .nickname("Sungchul")
+                    .startDate(LocalDate.now().minusDays(10))
+                    .endDate(LocalDate.now().minusDays(1))
+                    .build();
+            //when
+            when(missionService.findEndList(eq(pageable), any())).thenReturn(endMissionListResponse);
+            ResultActions resultActions = mockMvc.perform(get("/api/v1/mission/end")
+                    .param("page", String.valueOf(pageable.getPageNumber()))
+                    .param("size", String.valueOf(pageable.getPageSize()))
+                    .with(csrf()))
+               .andExpect(status().isOk())
+               .andDo(print());
+
+            //then
+            resultActions.andExpect(jsonPath("$.success").value(true));
+            resultActions.andExpect(jsonPath("$.code").value(200));
+            resultActions.andExpect(jsonPath("$.data[0].id").value(endMission_1.getId()));
+            resultActions.andExpect(jsonPath("$.data[0].title").value(endMission_1.getTitle()));
+            resultActions.andExpect(jsonPath("$.data[0].content").value(endMission_1.getContent()));
+            resultActions.andExpect(jsonPath("$.data[0].imageUrl").value(endMission_1.getImageUrl()));
+            resultActions.andExpect(jsonPath("$.data[0].nickname").value(endMission_1.getNickname()));
+            resultActions.andExpect(jsonPath("$.data[0].startDate").value(endMission_1.getStartDate().toString()));
+            resultActions.andExpect(jsonPath("$.data[0].endDate").value(endMission_1.getEndDate().toString()));
         }
 
         @Test

--- a/src/test/java/dailymissionproject/demo/domain/mission/fixture/MissionObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/fixture/MissionObjectFixture.java
@@ -1,20 +1,15 @@
 package dailymissionproject.demo.domain.mission.fixture;
 
-import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import dailymissionproject.demo.domain.mission.dto.page.PageResponseDto;
 import dailymissionproject.demo.domain.mission.dto.request.MissionSaveRequestDto;
 import dailymissionproject.demo.domain.mission.dto.request.MissionUpdateRequestDto;
 import dailymissionproject.demo.domain.mission.dto.response.*;
 import dailymissionproject.demo.domain.mission.repository.Mission;
-import dailymissionproject.demo.domain.mission.repository.QMission;
 import dailymissionproject.demo.domain.missionRule.dto.MissionRuleResponseDto;
 import dailymissionproject.demo.domain.missionRule.repository.MissionRule;
 import dailymissionproject.demo.domain.missionRule.repository.Week;
 import dailymissionproject.demo.domain.participant.dto.response.ParticipantUserDto;
 import dailymissionproject.demo.domain.participant.repository.Participant;
-import dailymissionproject.demo.domain.participant.repository.QParticipant;
 import dailymissionproject.demo.domain.user.repository.Role;
 import dailymissionproject.demo.domain.user.repository.User;
 import org.springframework.data.domain.PageRequest;
@@ -359,6 +354,37 @@ public class MissionObjectFixture {
 
         Slice<MissionAllListResponseDto> allMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
         PageResponseDto pageResponse = new PageResponseDto(allMissionListResponse.getContent(), allMissionListResponse.hasNext());
+        return pageResponse;
+    }
+
+    public static PageResponseDto getEndMissionListResponse(){
+        MissionEndedListResponseDto endMission_1 = MissionEndedListResponseDto.builder()
+                .id(1L)
+                .title("종료미션")
+                .content("종료된 미션입니다.")
+                .imageUrl("END_THUMBNAIL1.jpg")
+                .nickname("Sungchul")
+                .startDate(LocalDate.now().minusDays(10))
+                .endDate(LocalDate.now().minusDays(1))
+                .build();
+
+        MissionEndedListResponseDto endMission_2 = MissionEndedListResponseDto.builder()
+                .id(2L)
+                .title("미션2")
+                .content("화이팅합시다!")
+                .imageUrl("THUMBNAIL2.jpg")
+                .nickname("sungchul")
+                .startDate(LocalDate.now().minusDays(7))
+                .endDate(LocalDate.now().plusDays(7))
+                .build();
+
+        List<MissionEndedListResponseDto> listResponse = List.of(endMission_1, endMission_2);
+
+        boolean hasNext = false;
+        Pageable pageable = PageRequest.of(0, 3);
+
+        Slice<MissionEndedListResponseDto> endMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
+        PageResponseDto pageResponse = new PageResponseDto(endMissionListResponse.getContent(), endMissionListResponse.hasNext());
         return pageResponse;
     }
 

--- a/src/test/java/dailymissionproject/demo/domain/mission/fixture/MissionObjectFixture.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/fixture/MissionObjectFixture.java
@@ -162,7 +162,12 @@ public class MissionObjectFixture {
                 .build();
     }
 
-    public static Slice<MissionHotListResponseDto> getHotMissionListPageable(){
+    /**
+     * 미션 Collection 객체를 반환합니다.
+     * 신규, 인기, 전체, 종료
+     * @return List<T>
+     */
+    public static List<MissionHotListResponseDto> getHotMissions(){
         MissionHotListResponseDto hotMission_1 = MissionHotListResponseDto.builder()
                 .id(1L)
                 .title("미션1")
@@ -183,16 +188,10 @@ public class MissionObjectFixture {
                 .endDate(LocalDate.now().plusDays(7))
                 .build();
 
-        List<MissionHotListResponseDto> listResponse = List.of(hotMission_1, hotMission_2);
-
-        boolean hasNext = false;
-        Pageable pageable = PageRequest.of(0, 3);
-
-        Slice<MissionHotListResponseDto> hotMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        return hotMissionListResponse;
+        return List.of(hotMission_1, hotMission_2);
     }
 
-    public static Slice<MissionNewListResponseDto> getNewMissionListPageable(){
+    public static List<MissionNewListResponseDto> getNewMissions(){
         MissionNewListResponseDto newMission_1 = MissionNewListResponseDto.builder()
                 .id(1L)
                 .title("미션1")
@@ -213,19 +212,10 @@ public class MissionObjectFixture {
                 .endDate(LocalDate.now().plusDays(7))
                 .build();
 
-        List<MissionNewListResponseDto> listResponse = List.of(newMission_1, newMission_2);
-
-        boolean hasNext = false;
-        Pageable pageable = PageRequest.of(0, 3);
-
-        Slice<MissionNewListResponseDto> newMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        return newMissionListResponse;
+        return List.of(newMission_1, newMission_2);
     }
-    /**
-     * 인기 미션 리스트 응답 객체를 반환합니다.
-     * @return PageResponseDto
-     */
-    public static Slice<MissionAllListResponseDto> getAllMissionListPageable(){
+
+    public static List<MissionAllListResponseDto> getAllMissions(){
         MissionAllListResponseDto allMission_1 = MissionAllListResponseDto.builder()
                 .id(1L)
                 .title("미션1")
@@ -246,118 +236,10 @@ public class MissionObjectFixture {
                 .endDate(LocalDate.now().plusDays(7))
                 .build();
 
-        List<MissionAllListResponseDto> listResponse = List.of(allMission_1, allMission_2);
-
-        boolean hasNext = false;
-        Pageable pageable = PageRequest.of(0, 3);
-
-        Slice<MissionAllListResponseDto> allMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        return allMissionListResponse;
+        return List.of(allMission_1, allMission_2);
     }
 
-
-    public static PageResponseDto getHotMissionListResponse(){
-        MissionHotListResponseDto hotMission_1 = MissionHotListResponseDto.builder()
-                .id(1L)
-                .title("미션1")
-                .content("열심히 합니다.")
-                .imageUrl("THUMBNAIL1.jpg")
-                .nickname("yoonsu")
-                .startDate(LocalDate.now().minusDays(10))
-                .endDate(LocalDate.now().plusDays(10))
-                .build();
-
-        MissionHotListResponseDto hotMission_2 = MissionHotListResponseDto.builder()
-                .id(2L)
-                .title("미션2")
-                .content("화이팅합시다!")
-                .imageUrl("THUMBNAIL2.jpg")
-                .nickname("sungchul")
-                .startDate(LocalDate.now().minusDays(7))
-                .endDate(LocalDate.now().plusDays(7))
-                .build();
-
-        List<MissionHotListResponseDto> listResponse = List.of(hotMission_1, hotMission_2);
-
-        boolean hasNext = false;
-        Pageable pageable = PageRequest.of(0, 3);
-
-        Slice<MissionHotListResponseDto> hotMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        PageResponseDto pageResponse = new PageResponseDto(hotMissionListResponse.getContent(), hotMissionListResponse.hasNext());
-        return pageResponse;
-    }
-
-    /**
-     * 신규 미션 리스트 응답 객체를 반환합니다.
-     * @return PageResponseDto
-     */
-    public static PageResponseDto getNewMissionListResponse(){
-        MissionNewListResponseDto newMission_1 = MissionNewListResponseDto.builder()
-                .id(1L)
-                .title("미션1")
-                .content("열심히 합니다.")
-                .imageUrl("THUMBNAIL1.jpg")
-                .nickname("yoonsu")
-                .startDate(LocalDate.now().minusDays(10))
-                .endDate(LocalDate.now().plusDays(10))
-                .build();
-
-        MissionNewListResponseDto newMission_2 = MissionNewListResponseDto.builder()
-                .id(2L)
-                .title("미션2")
-                .content("화이팅합시다!")
-                .imageUrl("THUMBNAIL2.jpg")
-                .nickname("sungchul")
-                .startDate(LocalDate.now().minusDays(7))
-                .endDate(LocalDate.now().plusDays(7))
-                .build();
-
-        List<MissionNewListResponseDto> listResponse = List.of(newMission_1, newMission_2);
-
-        boolean hasNext = false;
-        Pageable pageable = PageRequest.of(0, 3);
-
-        Slice<MissionNewListResponseDto> newMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        PageResponseDto pageResponse = new PageResponseDto(newMissionListResponse.getContent(), newMissionListResponse.hasNext());
-        return pageResponse;
-    }
-
-    /**
-     * 전체 미션 리스트 응답 객체를 반환합니다.
-     * @return PageResponseDto
-     */
-    public static PageResponseDto getAllMissionListResponse(){
-        MissionAllListResponseDto allMission_1 = MissionAllListResponseDto.builder()
-                .id(1L)
-                .title("미션1")
-                .content("열심히 합니다.")
-                .imageUrl("THUMBNAIL1.jpg")
-                .nickname("yoonsu")
-                .startDate(LocalDate.now().minusDays(10))
-                .endDate(LocalDate.now().plusDays(10))
-                .build();
-
-        MissionAllListResponseDto allMission_2 = MissionAllListResponseDto.builder()
-                .id(2L)
-                .title("미션2")
-                .content("화이팅합시다!")
-                .imageUrl("THUMBNAIL2.jpg")
-                .nickname("sungchul")
-                .startDate(LocalDate.now().minusDays(7))
-                .endDate(LocalDate.now().plusDays(7))
-                .build();
-
-        List<MissionAllListResponseDto> listResponse = List.of(allMission_1, allMission_2);
-
-        boolean hasNext = false;
-        Pageable pageable = PageRequest.of(0, 3);
-
-        Slice<MissionAllListResponseDto> allMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        PageResponseDto pageResponse = new PageResponseDto(allMissionListResponse.getContent(), allMissionListResponse.hasNext());
-        return pageResponse;
-    }
-
-    public static PageResponseDto getEndMissionListResponse(){
+    public static List<MissionEndedListResponseDto> getEndMissions(){
         MissionEndedListResponseDto endMission_1 = MissionEndedListResponseDto.builder()
                 .id(1L)
                 .title("종료미션")
@@ -374,18 +256,71 @@ public class MissionObjectFixture {
                 .content("화이팅합시다!")
                 .imageUrl("THUMBNAIL2.jpg")
                 .nickname("sungchul")
-                .startDate(LocalDate.now().minusDays(7))
-                .endDate(LocalDate.now().plusDays(7))
+                .startDate(LocalDate.now().minusDays(10))
+                .endDate(LocalDate.now().minusDays(1))
                 .build();
 
-        List<MissionEndedListResponseDto> listResponse = List.of(endMission_1, endMission_2);
+        return List.of(endMission_1, endMission_2);
+    }
 
+    /**
+     * Slice 타입의 각 미션 리스트 응답객체를 반환합니다.
+     * @return
+     */
+    public static Slice<MissionHotListResponseDto> getHotMissionPageable(){
+        List<MissionHotListResponseDto> hotMissions = getHotMissions();
         boolean hasNext = false;
         Pageable pageable = PageRequest.of(0, 3);
 
-        Slice<MissionEndedListResponseDto> endMissionListResponse = new SliceImpl<>(listResponse, pageable ,hasNext);
-        PageResponseDto pageResponse = new PageResponseDto(endMissionListResponse.getContent(), endMissionListResponse.hasNext());
-        return pageResponse;
+        return new SliceImpl<>(hotMissions, pageable, hasNext);
+    }
+
+    public static Slice<MissionNewListResponseDto> getNewMissionPageable(){
+        List<MissionNewListResponseDto> newMissions = getNewMissions();
+        boolean hasNext = false;
+        Pageable pageable = PageRequest.of(0, 3);
+
+        return new SliceImpl<>(newMissions, pageable ,hasNext);
+    }
+
+    public static Slice<MissionAllListResponseDto> getAllMissionPageable(){
+        List<MissionAllListResponseDto> allMissions = getAllMissions();
+        boolean hasNext = false;
+        Pageable pageable = PageRequest.of(0, 3);
+
+        return new SliceImpl<>(allMissions, pageable ,hasNext);
+    }
+
+    public static Slice<MissionEndedListResponseDto> getEndMissionPageable(){
+        List<MissionEndedListResponseDto> endMissions = getEndMissions();
+        boolean hasNext = false;
+        Pageable pageable = PageRequest.of(0, 3);
+
+        return new SliceImpl<>(endMissions, pageable ,hasNext);
+    }
+
+    /**
+     * 각 미션별 리스트를 PageResponseDto 타입 객체로 반환합니다.
+     * @return
+     */
+    public static PageResponseDto getHotMissionListResponse(){
+        Slice<MissionHotListResponseDto> hotMissionListResponse = getHotMissionPageable();
+        return new PageResponseDto(getHotMissionPageable().getContent(), hotMissionListResponse.hasNext());
+    }
+
+    public static PageResponseDto getNewMissionListResponse(){
+        Slice<MissionNewListResponseDto> newMissionListResponse = getNewMissionPageable();
+        return new PageResponseDto(newMissionListResponse.getContent(), newMissionListResponse.hasNext());
+    }
+
+    public static PageResponseDto getAllMissionListResponse(){
+        Slice<MissionAllListResponseDto> allMissionListResponse = getAllMissionPageable();
+        return new PageResponseDto(allMissionListResponse.getContent(), allMissionListResponse.hasNext());
+    }
+
+    public static PageResponseDto getEndMissionListResponse(){
+        Slice<MissionEndedListResponseDto> endMissionListResponse = getEndMissionPageable();
+        return new PageResponseDto(endMissionListResponse.getContent(), endMissionListResponse.hasNext());
     }
 
     public static List<MissionUserListResponseDto> getUserMissionList(){

--- a/src/test/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/repository/MissionRepositoryTest.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import dailymissionproject.demo.common.config.JPAConfig;
 import dailymissionproject.demo.common.config.QueryDSLConfig;
 import dailymissionproject.demo.domain.mission.dto.response.MissionAllListResponseDto;
+import dailymissionproject.demo.domain.mission.dto.response.MissionEndedListResponseDto;
 import dailymissionproject.demo.domain.mission.dto.response.MissionHotListResponseDto;
 import dailymissionproject.demo.domain.mission.dto.response.MissionNewListResponseDto;
 import dailymissionproject.demo.domain.mission.fixture.MissionObjectFixture;
@@ -107,6 +108,9 @@ class MissionRepositoryTest {
                 Mission.builder().missionRule(missionRules.get(8)).user(users.get(8)).title("영화 감상").content("주말마다 영화 한 편 보기").imageUrl("http://example.com/mission9.png").hint("HINT").credential("CREDENTIAL").startDate(LocalDate.now().minusMonths(3)).endDate(LocalDate.now().plusMonths(3)).build(),
                 Mission.builder().missionRule(missionRules.get(9)).user(users.get(9)).title("요리 연습하기").content("매일 새로운 요리 시도하기").imageUrl("http://example.com/mission10.png").hint("HINT").credential("CREDENTIAL").startDate(LocalDate.now().minusMonths(4)).endDate(LocalDate.now().plusMonths(3)).build()
         );
+        missions.get(9).end();
+        missions.get(8).end();
+        missions.get(7).end();
         missionRepository.saveAll(missions);
     }
 
@@ -246,6 +250,40 @@ class MissionRepositoryTest {
             Slice<MissionAllListResponseDto> sliceList = new SliceImpl<>(missionList, pageable, hasNext);
 
             assertThat(sliceList.getContent().size()).isEqualTo(pageable.getPageSize());
+        }
+
+        @Test
+        @DisplayName("종료된 미션 리스트를 조회할 수 있다.")
+        void mission_read_end_list(){
+            Pageable pageable = PageRequest.of(0,3);
+
+            List<MissionEndedListResponseDto> endMissions = queryFactory
+                    .select(Projections.fields(MissionEndedListResponseDto.class,
+                            mission.id,
+                            mission.title,
+                            mission.content,
+                            mission.imageUrl,
+                            mission.user.nickname,
+                            mission.startDate,
+                            mission.endDate
+                    ))
+                    .from(mission)
+                    .where(mission.ended.isTrue())
+                    .orderBy(mission.endDate.desc())
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize() + 1)
+                    .fetch();
+
+            boolean hasNext = false;
+
+            if(endMissions.size() > pageable.getPageSize()){
+                endMissions.remove(pageable.getPageSize());
+                hasNext = true;
+            }
+
+            Slice<MissionEndedListResponseDto> sliceList = new SliceImpl<>(endMissions, pageable, hasNext);
+
+            assertThat(endMissions.size()).isEqualTo(pageable.getPageSize());
         }
     }
 }

--- a/src/test/java/dailymissionproject/demo/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/dailymissionproject/demo/domain/mission/service/MissionServiceTest.java
@@ -33,19 +33,15 @@ import org.springframework.security.test.context.support.WithMockUser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static dailymissionproject.demo.domain.mission.exception.MissionExceptionCode.*;
-import static dailymissionproject.demo.domain.mission.fixture.MissionObjectFixture.getMissionList;
-import static dailymissionproject.demo.domain.mission.fixture.MissionObjectFixture.getUserMissionList;
+import static dailymissionproject.demo.domain.mission.fixture.MissionObjectFixture.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 @Tag("unit")
 @DisplayName("[unit] [service] MissionService")
@@ -172,37 +168,50 @@ class MissionServiceTest {
             @Test
             @DisplayName("인기 미션 리스트를 조회할 수 있다.")
             void test_mission_read_hot_list_success() {
-                when(missionRepository.findAllByParticipantSize(pageable, 1L)).thenReturn(MissionObjectFixture.getHotMissionListPageable());
+                when(missionRepository.findAllByParticipantSize(pageable, 1L)).thenReturn(MissionObjectFixture.getHotMissionPageable());
 
                 PageResponseDto pageResponseDto = missionService.findHotList(pageable, oAuth2User);
                 List<MissionHotListResponseDto> list = (List<MissionHotListResponseDto>) pageResponseDto.content();
 
                 assertEquals(list.get(0).getTitle(),
-                        MissionObjectFixture.getHotMissionListPageable().getContent().get(0).getTitle());
+                        MissionObjectFixture.getHotMissionPageable().getContent().get(0).getTitle());
             }
 
             @Test
             @DisplayName("신규 미션 리스트를 조회할 수 있다.")
             void test_mission_read_new_list_success() {
-                when(missionRepository.findAllByCreatedInMonth(pageable, 1L)).thenReturn(MissionObjectFixture.getNewMissionListPageable());
+                when(missionRepository.findAllByCreatedInMonth(pageable, 1L)).thenReturn(MissionObjectFixture.getNewMissionPageable());
 
                 PageResponseDto pageResponseDto = missionService.findNewList(pageable, oAuth2User);
                 List<MissionNewListResponseDto> list = (List<MissionNewListResponseDto>) pageResponseDto.content();
 
                 assertEquals(list.get(0).getTitle(),
-                        MissionObjectFixture.getNewMissionListPageable().getContent().get(0).getTitle());
+                        MissionObjectFixture.getNewMissionPageable().getContent().get(0).getTitle());
             }
 
             @Test
             @DisplayName("전체 미션 리스트를 조회할 수 있다.")
             void test_mission_read_all_list_success() {
-                when(missionRepository.findAllByCreatedDate(pageable, 1L)).thenReturn(MissionObjectFixture.getAllMissionListPageable());
+                when(missionRepository.findAllByCreatedDate(pageable, 1L)).thenReturn(MissionObjectFixture.getAllMissionPageable());
 
                 PageResponseDto pageResponseDto = missionService.findAllList(pageable, oAuth2User);
                 List<MissionAllListResponseDto> list = (List<MissionAllListResponseDto>) pageResponseDto.content();
 
                 assertEquals(list.get(0).getTitle(),
-                        MissionObjectFixture.getAllMissionListPageable().getContent().get(0).getTitle());
+                        MissionObjectFixture.getAllMissionPageable().getContent().get(0).getTitle());
+            }
+
+            @Test
+            @DisplayName("종료 미션 리스트를 조회할 수 있다.")
+            void test_mission_read_end_list_success(){
+                //when
+                when(missionRepository.findAllByEnded(pageable, 1L)).thenReturn(MissionObjectFixture.getEndMissionPageable());
+
+                PageResponseDto pageResponseDto = missionService.findEndList(pageable, oAuth2User);
+                List<MissionEndedListResponseDto> endMissions = (List<MissionEndedListResponseDto>) pageResponseDto.content();
+
+                //then
+                assertEquals(getEndMissions().get(0).getTitle(), endMissions.get(0).getTitle());
             }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #114 

## 📝작업 내용

> 종료 미션 리스트 조회 기능 추가
>
- 종료 미션 응답 DTO 작성
- GET /end 엔드포인트 추가 및 swagger 반영
- 종료 미션 리스트 조회 쿼리 작성(DSL) 및 페이지네이션 적용
- 기능 단위테스트 작성(Controller, Service, Repository Layer) 및 종료미션 mock 추가